### PR TITLE
Increase the size of the name of the log file

### DIFF
--- a/src/log.f90
+++ b/src/log.f90
@@ -116,7 +116,7 @@ contains
       integer :: io_unit
       integer :: version, subversion, ierror
 #ifdef DEBUG
-      character(len=64) :: fname
+      character(len=512) :: fname
 #endif
 
       ! Output log if needed


### PR DESCRIPTION
The file returned can contain the absolute path and can be relatively long.