### PR TITLE
Correct halo test

### DIFF
--- a/examples/halo_test/halo_test.f90
+++ b/examples/halo_test/halo_test.f90
@@ -103,7 +103,7 @@ program halo_test
    end if
 
    call initialise()
-   !$acc data copyin(u1,v1,w1) create(u2,v2,w2,u3,v3,w3,div1,div2,div3,wk2,wk3) copy(div)
+   !$acc data copyin(u1,v1,w1) create(u2,v2,w2,u3,v3,w3,wk2,wk3) copy(div)
    call test_div_transpose()
    call test_div_haloX()
    call test_div_haloY()
@@ -333,6 +333,7 @@ contains
       call test_halo_size(vh, nx_expected, ny_expected, nz_expected, "X:v")
       call test_halo_size(wh, nx_expected, ny_expected, nz_expected, "X:w")
 
+      !$acc data copy(div1)
       !$acc kernels default(present)
       div1(:, :, :) = 0._mytype
       !$acc end kernels
@@ -350,6 +351,7 @@ contains
 
       ! Compute error
       call check_err(div1, div, "X")
+      !$acc end data
 
       deallocate (vh, wh, div1)
 
@@ -405,6 +407,7 @@ contains
       call test_halo_size(uh, nx_expected, ny_expected, nz_expected, "Y:u")
       call test_halo_size(wh, nx_expected, ny_expected, nz_expected, "Y:w")
 
+      !$acc data copy(div2)
       !$acc kernels default(present)
       do k = kfirst, klast
          do j = jfirst, jlast
@@ -421,6 +424,7 @@ contains
 
       ! Compute error
       call check_err(div2, div, "Y")
+      !$acc end data
 
       deallocate (uh, wh, div2)
 
@@ -477,6 +481,7 @@ contains
       call test_halo_size(uh, nx_expected, ny_expected, nz_expected, "Z:u")
       call test_halo_size(vh, nx_expected, ny_expected, nz_expected, "Z:v")
 
+      !$acc data copy(div3)
       !$acc kernels default(present)
       do j = jfirst, jlast
          do i = ifirst, ilast
@@ -494,6 +499,7 @@ contains
 
       ! Compute error
       call check_err(div3, div, "Z")
+      !$acc end data
 
       deallocate (uh, vh, div3)
    end subroutine test_div_haloZ

--- a/examples/halo_test/halo_test.f90
+++ b/examples/halo_test/halo_test.f90
@@ -27,9 +27,9 @@ program halo_test
    integer :: nargin, arg, FNLength, status, DecInd
    character(len=80) :: InputFN
 
-   real(mytype), allocatable, dimension(:, :, :) :: u1, v1, w1, div1
-   real(mytype), allocatable, dimension(:, :, :) :: u2, v2, w2, div2
-   real(mytype), allocatable, dimension(:, :, :) :: u3, v3, w3, div3
+   real(mytype), allocatable, dimension(:, :, :) :: u1, v1, w1
+   real(mytype), allocatable, dimension(:, :, :) :: u2, v2, w2
+   real(mytype), allocatable, dimension(:, :, :) :: u3, v3, w3
    real(mytype), allocatable, dimension(:, :, :) :: div, wk2, wk3
 
    integer :: i, j, k, ierror, n
@@ -146,9 +146,6 @@ contains
       call alloc_x(v1, global)
       call alloc_x(w1, global)
       call alloc_x(div, global)
-      call alloc_x(div1, global)
-      call alloc_x(div2, global)
-      call alloc_x(div3, global)
 
       call random_seed(size=n)
       allocate (seed(n))
@@ -293,6 +290,7 @@ contains
 
       implicit none
 
+      real(mytype), allocatable, dimension(:, :, :) :: div1
       real(mytype), allocatable, dimension(:, :, :) :: vh, wh
 #if defined(_GPU)
       attributes(device) :: vh, wh
@@ -306,6 +304,8 @@ contains
       integer :: ifirst, ilast ! I loop start/end
       integer :: jfirst, jlast ! J loop start/end
       integer :: kfirst, klast ! K loop start/end
+
+      call alloc_x(div1, global)
 
       ! Expected sizes
       nx_expected = nx
@@ -351,7 +351,7 @@ contains
       ! Compute error
       call check_err(div1, div, "X")
 
-      deallocate (vh, wh)
+      deallocate (vh, wh, div1)
 
    end subroutine test_div_haloX
 
@@ -361,6 +361,8 @@ contains
    subroutine test_div_haloY()
 
       implicit none
+
+      real(mytype), allocatable, dimension(:, :, :) :: div2
       real(mytype), allocatable, dimension(:, :, :) :: uh, wh
 #if defined(_GPU)
       attributes(device) :: uh, wh
@@ -375,6 +377,8 @@ contains
       integer :: jfirst, jlast ! J loop start/end
       integer :: kfirst, klast ! K loop start/end
 
+      call alloc_x(div2, global)
+      
       ! Expected sizes
       nx_expected = ysize(1) + 2
       ny_expected = ny
@@ -418,7 +422,7 @@ contains
       ! Compute error
       call check_err(div2, div, "Y")
 
-      deallocate (uh, wh)
+      deallocate (uh, wh, div2)
 
    end subroutine test_div_haloY
 
@@ -428,6 +432,9 @@ contains
    subroutine test_div_haloZ()
 
       implicit none
+
+      real(mytype), allocatable, dimension(:, :, :) :: div3
+      
       real(mytype), allocatable, dimension(:, :, :) :: uh, vh
 #if defined(_GPU)
       attributes(device) :: vh, uh
@@ -441,6 +448,8 @@ contains
       integer :: ifirst, ilast ! I loop start/end
       integer :: jfirst, jlast ! J loop start/end
       integer :: kfirst, klast ! K loop start/end
+
+      call alloc_x(div3, global)
 
       ! Expected sizes
       nx_expected = zsize(1) + 2
@@ -486,7 +495,7 @@ contains
       ! Compute error
       call check_err(div3, div, "Z")
 
-      deallocate (uh, vh)
+      deallocate (uh, vh, div3)
    end subroutine test_div_haloZ
    !=====================================================================
    ! Check the difference between halo and transpose divergence

--- a/examples/halo_test/halo_test.f90
+++ b/examples/halo_test/halo_test.f90
@@ -349,7 +349,7 @@ contains
       !$acc end kernels
 
       ! Compute error
-      call check_err(div1, "X")
+      call check_err(div1, div, "X")
 
       deallocate (vh, wh)
 
@@ -416,7 +416,7 @@ contains
       call transpose_y_to_x(wk2, div2)
 
       ! Compute error
-      call check_err(div2, "Y")
+      call check_err(div2, div, "Y")
 
       deallocate (uh, wh)
 
@@ -484,18 +484,19 @@ contains
       call transpose_y_to_x(wk2, div3)
 
       ! Compute error
-      call check_err(div3, "Z")
+      call check_err(div3, div, "Z")
 
       deallocate (uh, vh)
    end subroutine test_div_haloZ
    !=====================================================================
    ! Check the difference between halo and transpose divergence
    !=====================================================================
-   subroutine check_err(divh, pencil)
+   subroutine check_err(divh, divref, pencil)
 
       implicit none
 
       real(mytype), dimension(:, :, :), intent(in) :: divh
+      real(mytype), dimension(:, :, :), intent(in) :: divref
       character(len=*), intent(in) :: pencil
       real(mytype), dimension(:, :, :), allocatable :: tmp
       real(mytype) :: divmag, error
@@ -509,11 +510,11 @@ contains
       allocate (tmp(size(divh, 1), size(divh, 2), size(divh, 3)))
 
       !$acc kernels default(present)
-      tmp(2:xlast, 2:ylast, 2:zlast) = divh(2:xlast, 2:ylast, 2:zlast) - div1(2:xlast, 2:ylast, 2:zlast)
+      tmp(2:xlast, 2:ylast, 2:zlast) = divh(2:xlast, 2:ylast, 2:zlast) - divref(2:xlast, 2:ylast, 2:zlast)
       !$acc end kernels
       error = mag(tmp)
       !$acc kernels default(present)
-      tmp(2:xlast, 2:ylast, 2:zlast) = div1(2:xlast, 2:ylast, 2:zlast)
+      tmp(2:xlast, 2:ylast, 2:zlast) = divref(2:xlast, 2:ylast, 2:zlast)
       !$acc end kernels
       divmag = mag(tmp)
 


### PR DESCRIPTION
The test originally used `div1` (global) as the reference data, this has been replaced to use data local to each test subroutine and the correct reference data (`div`, computed via transpose) used in the error check.

I'm not sure about the openACC data copy in/out for div1/2/3 though