### PR TITLE
Silence Cray warning about multiple module uses

### DIFF
--- a/cmake/compilers/D2D_flags_cray.cmake
+++ b/cmake/compilers/D2D_flags_cray.cmake
@@ -1,5 +1,5 @@
 #Compilers Flags for Cray
 
-set(D2D_FFLAGS "-eF -g -N 1023")
+set(D2D_FFLAGS "-eF -g -N 1023 -M878")
 set(D2D_FFLAGS_RELEASE "-O3")
 set(D2D_FFLAGS_DEBUG   "-O0 -g")


### PR DESCRIPTION
If module A uses MPI (for example) and module B uses modules A and MPI then this raises a warning. It seems safe to ignore so this silences it