### PR TITLE
Fix intel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,10 @@ project(decomp2d
   LANGUAGES Fortran)
 set(version 2.0.0)
 enable_testing()
-# Can be useful to also activate CXX, sometimes is needed by packages
-enable_language(C CXX)
+if (IO_BACKEND MATCHES "adios2")
+  # Can be useful to also activate CXX, sometimes is needed by packages
+  enable_language(C CXX)
+endif (IO_BACKEND MATCHES "adios2")
 
 
 set(BUILD_TARGET "mpi" CACHE STRING "Target for acceleration (mpi (default) or gpu)")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,6 +163,22 @@ Note that when using `caliper` a C++ compiler is required as indicated in the ab
 
 ## Miscellaneous
 
+### Compiling with Intel oneAPI
+In order to compile with the MKL libraries the following environmental variable needs to be set up
+```
+export MKL_DIR=${MKLROOT}/lib/cmake/mkl
+```
+and activate set the `FFT_Choice=mkl`
+To use the new IntelLLVM compiler you can 
+```
+export export FC="mpiifort -fc=ifx"
+```
+and in case of compilatio with ADIOS2 also the `C` and `CXX` compilers needs to be set-up
+```
+export CXX="mpiicpc -cxx=icpx"
+export CC="mpiicc -cc=icx"
+```
+
 ### List of preprocessor variables
 
 #### ADIOS2

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,16 +164,18 @@ Note that when using `caliper` a C++ compiler is required as indicated in the ab
 ## Miscellaneous
 
 ### Compiling with Intel oneAPI
+
 In order to compile with the MKL libraries the following environmental variable needs to be set up
 ```
 export MKL_DIR=${MKLROOT}/lib/cmake/mkl
 ```
-and activate set the `FFT_Choice=mkl`
-To use the new IntelLLVM compiler you can 
+and select the MKL backend by setting `FFT_Choice=mkl`.
+
+To use the new IntelLLVM compiler specify it as the Fortran compiler using
 ```
 export export FC="mpiifort -fc=ifx"
 ```
-and in case of compilatio with ADIOS2 also the `C` and `CXX` compilers needs to be set-up
+and when building with ADIOS2 support you must also specify the `C` and `CXX` compilers
 ```
 export CXX="mpiicpc -cxx=icpx"
 export CC="mpiicc -cc=icx"

--- a/cmake/compilers/D2D_flags_intel.cmake
+++ b/cmake/compilers/D2D_flags_intel.cmake
@@ -1,7 +1,12 @@
 # Compilers Flags for Intel
-
-set(D2D_FFLAGS "-fpp -std08 -xHost -heaparrays -safe-cray-ptr -g -traceback")
-set(D2D_FFLAGS_RELEASE "-O3 -ipo")
+# Check is the compiler is the new ifx based on LLVM or the old ifort
+if (Fortran_COMPILER_NAME MATCHES "IntelLLVM")
+  set(D2D_FFLAGS "-fpp -std08")
+  set(D2D_FFLAGS_RELEASE "-O2")
+else (Fortran_COMPILER_NAME MATCHES "IntelLLVM")
+  #set(CMAKE_Fortran_FLAGS "-cpp xSSE4.2 -axAVX,CORE-AVX-I,CORE-AVX2 -ipo -fp-model fast=2 -mcmodel=large -safe-cray-ptr")
+  set(D2D_FFLAGS "-fpp -std08 -xHost -heaparrays -safe-cray-ptr -g -traceback")
+  set(D2D_FFLAGS_RELEASE "-O3 -ipo")
+endif (Fortran_COMPILER_NAME MATCHES "IntelLLVM")
 set(D2D_FFLAGS_DEBUG   "-g -O0 -debug extended -traceback -DDEBUG")
 set(D2D_FFLAGS_DEV     "${D2D_FFLAGS_DEBUG} -warn all,noexternal")
-#set(CMAKE_Fortran_FLAGS "-cpp xSSE4.2 -axAVX,CORE-AVX-I,CORE-AVX2 -ipo -fp-model fast=2 -mcmodel=large -safe-cray-ptr")

--- a/examples/io_test/io_read.f90
+++ b/examples/io_test/io_read.f90
@@ -34,7 +34,7 @@ program io_read
 
    character(len=*), parameter :: io_name = "test-io"
 #ifndef ADIOS2
-   logical ::file_exists
+   logical ::file_exists1, file_exists2, file_exists3
 #endif
 
    integer :: i, j, k, m, ierror
@@ -91,9 +91,11 @@ program io_read
 
 #ifndef ADIOS2
    if (nrank == 0) then
-      inquire (file="out/u1.dat", exist=file_exists)
-      if (.not. file_exists) then
-         call decomp_2d_abort(1, "Error, directory 'out' must exist before running io_read test case!")
+      inquire (file="out/u1.dat", exist=file_exists1)
+      inquire (file="out/u2.dat", exist=file_exists2)
+      inquire (file="out/u3.dat", exist=file_exists3)
+      if (.not. (file_exists1 .and. file_exists2 .and. file_exists3)) then
+         call decomp_2d_abort(1, "Error, data 'out/u<1,2,3>.dat' must exist before running io_read test case!")
       end if
    end if
 #endif

--- a/examples/io_test/io_read.f90
+++ b/examples/io_test/io_read.f90
@@ -34,7 +34,7 @@ program io_read
 
    character(len=*), parameter :: io_name = "test-io"
 #ifndef ADIOS2
-   logical ::dir_exists
+   logical ::file_exists
 #endif
 
    integer :: i, j, k, m, ierror
@@ -91,8 +91,8 @@ program io_read
 
 #ifndef ADIOS2
    if (nrank == 0) then
-      inquire (file="out", exist=dir_exists)
-      if (.not. dir_exists) then
+      inquire (file="out/u1.dat", exist=file_exists)
+      if (.not. file_exists) then
          call decomp_2d_abort(1, "Error, directory 'out' must exist before running io_read test case!")
       end if
    end if

--- a/src/factor.f90
+++ b/src/factor.f90
@@ -37,7 +37,6 @@ contains
       m = int(sqrt(real(num,8)))
       nfact = 1
       do i = 1, m
-         print *, 'Resu if ',i,(num / i * i)
          if (num / i * i == num) then
             factors(nfact) = i
             nfact = nfact + 1

--- a/src/factor.f90
+++ b/src/factor.f90
@@ -32,9 +32,12 @@ contains
       integer :: i, m
 
       ! find the factors <= sqrt(num)
-      m = int(sqrt(real(num)))
+      ! Cast the int as double to make sure of the correct result of sqrt
+      ! IntelLLVM got an issue with 1.0 but not with 1.d0 
+      m = int(sqrt(real(num,8)))
       nfact = 1
       do i = 1, m
+         print *, 'Resu if ',i,(num / i * i)
          if (num / i * i == num) then
             factors(nfact) = i
             nfact = nfact + 1


### PR DESCRIPTION
This PR is to address the issues with the Intel compiler raised in issue #211. 
The PR provides: 
- different flags for ifort and ifx compilers
- a fix for the IntelLLVM fortran compiler to have the correct result for the sqrt(1.0) by forcing the integer conversion to double and not single precision
- a different `inquire ` argument pointing to a file instead of a directory. 

Test have been performed using:
- IntelLLVM 2022.2.1
- ifort 2021.7.0.20221019
The ifort version testing has been done also using ADIOS2 for the IO backhand both in serial and parallel (up to 4 mpi rank). Both version of the Intel Fortran have been tested with the generic FFT and with the MKL. 