### PR TITLE
Profile transpose operations when no MPI communication is performed

### DIFF
--- a/src/transpose_x_to_y.f90
+++ b/src/transpose_x_to_y.f90
@@ -24,6 +24,10 @@
      integer :: istat, nsize
 #endif
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_x_y_r")
+#endif
+
      if (dims(1) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%xsz)
@@ -38,6 +42,10 @@
         call transpose_x_to_y_real(src, dst, decomp)
      end if
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_x_y_r")
+#endif
+
   end subroutine transpose_x_to_y_real_long
 
   subroutine transpose_x_to_y_real(src, dst, decomp)
@@ -50,10 +58,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_x_y_r")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -113,11 +117,6 @@
                             decomp%y1dist, decomp)
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_x_y_r")
-#endif
-
-     return
   end subroutine transpose_x_to_y_real
 
   subroutine transpose_x_to_y_complex_short(src, dst)
@@ -141,6 +140,11 @@
 #if defined(_GPU)
      integer :: istat, nsize
 #endif
+
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_x_y_c")
+#endif
+
      if (dims(1) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%xsz)
@@ -155,6 +159,10 @@
         call transpose_x_to_y_complex(src, dst, decomp)
      end if
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_x_y_c")
+#endif
+
   end subroutine transpose_x_to_y_complex_long
 
   subroutine transpose_x_to_y_complex(src, dst, decomp)
@@ -167,10 +175,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_x_y_c")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -231,11 +235,6 @@
                                decomp%y1dist, decomp)
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_x_y_c")
-#endif
-
-     return
   end subroutine transpose_x_to_y_complex
 
   subroutine mem_split_xy_real(in, n1, n2, n3, out, iproc, dist, decomp)

--- a/src/transpose_y_to_x.f90
+++ b/src/transpose_y_to_x.f90
@@ -24,6 +24,10 @@
      integer :: istat, nsize
 #endif
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_x_r")
+#endif
+
      if (dims(1) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%ysz)
@@ -38,6 +42,10 @@
         call transpose_y_to_x_real(src, dst, decomp)
      end if
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_x_r")
+#endif
+
   end subroutine transpose_y_to_x_real_long
 
   subroutine transpose_y_to_x_real(src, dst, decomp)
@@ -50,10 +58,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_x_r")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -113,11 +117,6 @@
                             decomp%x1dist, decomp)
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_x_r")
-#endif
-
-     return
   end subroutine transpose_y_to_x_real
 
   subroutine transpose_y_to_x_complex_short(src, dst)
@@ -141,6 +140,11 @@
 #if defined(_GPU)
      integer :: istat, nsize
 #endif
+
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_x_c")
+#endif
+
      if (dims(1) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%ysz)
@@ -155,6 +159,10 @@
         call transpose_y_to_x_complex(src, dst, decomp)
      end if
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_x_c")
+#endif
+
   end subroutine transpose_y_to_x_complex_long
 
   subroutine transpose_y_to_x_complex(src, dst, decomp)
@@ -167,10 +175,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_x_c")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -231,11 +235,6 @@
                                decomp%x1dist, decomp)
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_x_c")
-#endif
-
-     return
   end subroutine transpose_y_to_x_complex
 
   subroutine mem_split_yx_real(in, n1, n2, n3, out, iproc, dist, decomp)

--- a/src/transpose_y_to_z.f90
+++ b/src/transpose_y_to_z.f90
@@ -24,6 +24,10 @@
      integer :: istat, nsize
 #endif
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_z_r")
+#endif
+
      if (dims(2) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%ysz)
@@ -37,6 +41,10 @@
      else
         call transpose_y_to_z_real(src, dst, decomp)
      end if
+
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_z_r")
+#endif
 
   end subroutine transpose_y_to_z_real_long
 
@@ -54,10 +62,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_z_r")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -134,11 +138,6 @@
 
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_z_r")
-#endif
-
-     return
   end subroutine transpose_y_to_z_real
 
   subroutine transpose_y_to_z_complex_short(src, dst)
@@ -163,6 +162,10 @@
      integer :: istat, nsize
 #endif
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_z_c")
+#endif
+
      if (dims(2) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%ysz)
@@ -176,6 +179,10 @@
      else
         call transpose_y_to_z_complex(src, dst, decomp)
      end if
+
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_z_c")
+#endif
 
   end subroutine transpose_y_to_z_complex_long
 
@@ -193,10 +200,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_y_z_c")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -272,11 +275,6 @@
 
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_z_c")
-#endif
-
-     return
   end subroutine transpose_y_to_z_complex
 
   subroutine mem_split_yz_real(in, n1, n2, n3, out, iproc, dist, decomp)

--- a/src/transpose_z_to_y.f90
+++ b/src/transpose_z_to_y.f90
@@ -24,6 +24,10 @@
      integer :: istat, nsize
 #endif
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_z_y_r")
+#endif
+
      if (dims(2) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%zsz)
@@ -37,6 +41,10 @@
      else
         call transpose_z_to_y_real(src, dst, decomp)
      end if
+
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_z_y_r")
+#endif
 
   end subroutine transpose_z_to_y_real_long
 
@@ -54,10 +62,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_z_y_r")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -131,11 +135,6 @@
                             decomp%y2dist, decomp)
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_z_y_r")
-#endif
-
-     return
   end subroutine transpose_z_to_y_real
 
   subroutine transpose_z_to_y_complex_short(src, dst)
@@ -160,6 +159,10 @@
      integer :: istat, nsize
 #endif
 
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_start("transp_z_y_c")
+#endif
+
      if (dims(2) == 1) then
 #if defined(_GPU)
         nsize = product(decomp%zsz)
@@ -173,6 +176,10 @@
      else
         call transpose_z_to_y_complex(src, dst, decomp)
      end if
+
+#ifdef PROFILER
+     if (decomp_profiler_transpose) call decomp_profiler_end("transp_z_y_c")
+#endif
 
   end subroutine transpose_z_to_y_complex_long
 
@@ -190,10 +197,6 @@
 
      integer :: s1, s2, s3, d1, d2, d3
      integer :: ierror
-
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_start("transp_z_y_c")
-#endif
 
      s1 = SIZE(src, 1)
      s2 = SIZE(src, 2)
@@ -269,11 +272,6 @@
                                decomp%y2dist, decomp)
 #endif
 
-#ifdef PROFILER
-     if (decomp_profiler_transpose) call decomp_profiler_end("transp_z_y_c")
-#endif
-
-     return
   end subroutine transpose_z_to_y_complex
 
   ! pack/unpack ALLTOALL(V) buffers


### PR DESCRIPTION
Current transpose operations are not always profiled when p_row or p_col is equal to one.