### PR TITLE
Add a profiler none dummy module allowing removal of the PROFILER preprocessor directives.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,8 @@ list(APPEND files_fft fft_log.f90)
 
 if (ENABLE_PROFILER)
   file(GLOB prof_files profiler_${ENABLE_PROFILER}.f90)
+else (ENABLE_PROFILER)
+  file(GLOB prof_files profiler_none.f90)
 endif()
 
 set(SRCFILES ${files_decomp} ${files_fft} ${prof_files})

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -140,7 +140,7 @@ module decomp_2d
    !    0 => no profiling, default
    !    1 => Caliper (https://github.com/LLNL/Caliper)
    !
-   integer(kind(decomp_profiler_none)), save, public :: decomp_profiler = decomp_profiler_none
+   integer, save, public :: decomp_profiler = decomp_profiler_none
    ! Default : profile everything
    logical, save, public :: decomp_profiler_transpose = .true.
    logical, save, public :: decomp_profiler_io = .true.

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -9,6 +9,7 @@ module decomp_2d
    use factor
    use decomp_2d_constants
    use decomp_2d_mpi
+   use decomp_2d_profiler
 #if defined(_GPU)
    use cudafor
    use decomp_2d_cumpi
@@ -152,8 +153,7 @@ module decomp_2d
              transpose_x_to_y, transpose_y_to_z, &
              transpose_z_to_y, transpose_y_to_x, &
              decomp_info_init, decomp_info_finalize, partition, &
-             decomp_info_print, decomp_profiler_prep, &
-             decomp_profiler_start, decomp_profiler_end, &
+             decomp_info_print, &
              init_coarser_mesh_statS, fine_to_coarseS, &
              init_coarser_mesh_statV, fine_to_coarseV, &
              init_coarser_mesh_statP, fine_to_coarseP, &
@@ -266,46 +266,6 @@ module decomp_2d
       end subroutine decomp_info_print
 
    end interface
-
-   ! Generic interface to initialize the profiler
-   interface decomp_profiler_init
-      module subroutine decomp_profiler_init_noarg
-      end subroutine decomp_profiler_init_noarg
-   end interface decomp_profiler_init
-
-   ! Generic interface to finalize the profiler
-   interface decomp_profiler_fin
-      module subroutine decomp_profiler_fin_noarg
-      end subroutine decomp_profiler_fin_noarg
-   end interface decomp_profiler_fin
-
-   ! Generic interface for the profiler to log setup
-   interface decomp_profiler_log
-      module subroutine decomp_profiler_log_int(io_unit)
-         integer, intent(in) :: io_unit
-      end subroutine decomp_profiler_log_int
-   end interface decomp_profiler_log
-
-   ! Generic interface to prepare the profiler before init.
-   interface decomp_profiler_prep
-      module subroutine decomp_profiler_prep_bool(profiler_setup)
-         logical, dimension(4), intent(in), optional :: profiler_setup
-      end subroutine decomp_profiler_prep_bool
-   end interface decomp_profiler_prep
-
-   ! Generic interface for the profiler to start a given timer
-   interface decomp_profiler_start
-      module subroutine decomp_profiler_start_char(timer_name)
-         character(len=*), intent(in) :: timer_name
-      end subroutine decomp_profiler_start_char
-   end interface decomp_profiler_start
-
-   ! Generic interface for the profiler to end a given timer
-   interface decomp_profiler_end
-      module subroutine decomp_profiler_end_char(timer_name)
-         character(len=*), intent(in) :: timer_name
-      end subroutine decomp_profiler_end_char
-   end interface decomp_profiler_end
 
 contains
 

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -134,20 +134,6 @@ module decomp_2d
    integer, save :: iskipV, jskipV, kskipV
    integer, save :: iskipP, jskipP, kskipP
 
-   !
-   ! Profiler section
-   !
-   ! Integer to select the profiling tool
-   !    0 => no profiling, default
-   !    1 => Caliper (https://github.com/LLNL/Caliper)
-   !
-   integer, save, public :: decomp_profiler = decomp_profiler_none
-   ! Default : profile everything
-   logical, save, public :: decomp_profiler_transpose = .true.
-   logical, save, public :: decomp_profiler_io = .true.
-   logical, save, public :: decomp_profiler_fft = .true.
-   logical, save, public :: decomp_profiler_d2d = .true.
-
    ! public user routines
    public :: decomp_2d_init, decomp_2d_finalize, &
              transpose_x_to_y, transpose_y_to_z, &

--- a/src/decomp_2d_constants.f90
+++ b/src/decomp_2d_constants.f90
@@ -74,10 +74,8 @@ module decomp_2d_constants
    !    0 => no profiling, default
    !    1 => Caliper (https://github.com/LLNL/Caliper)
    !
-   enum, bind(c)
-      enumerator :: decomp_profiler_none = 0
-      enumerator :: decomp_profiler_caliper = 1
-   end enum
+   integer, parameter, public :: DECOMP_PROFILER_NONE = 0
+   integer, parameter, public :: DECOMP_PROFILER_CALIPER = 1
 
    !
    ! Supported FFT backends

--- a/src/decomp_2d_init_fin.f90
+++ b/src/decomp_2d_init_fin.f90
@@ -27,13 +27,7 @@
      logical, dimension(2) :: periodic
 
      ! Prepare the profiler if it was not already prepared
-     if (decomp_profiler == decomp_profiler_none) then
-        call decomp_profiler_prep(decomp_profiler, &
-                                  decomp_profiler_transpose, &
-                                  decomp_profiler_io, &
-                                  decomp_profiler_fft, &
-                                  decomp_profiler_d2d)
-     end if
+     if (decomp_profiler == decomp_profiler_none) call decomp_profiler_prep()
 
      ! Start the profiler
      call decomp_profiler_init()
@@ -200,7 +194,7 @@
 
      if (decomp_profiler_d2d) call decomp_profiler_end("decomp_2d_fin")
      ! Finalize the profiler
-     call decomp_profiler_fin(decomp_profiler)
+     call decomp_profiler_fin()
 
      return
   end subroutine decomp_2d_finalize_ref

--- a/src/decomp_2d_init_fin.f90
+++ b/src/decomp_2d_init_fin.f90
@@ -26,14 +26,12 @@
      integer :: errorcode, ierror, row, col, iounit
      logical, dimension(2) :: periodic
 
-#ifdef PROFILER
      ! Prepare the profiler if it was not already prepared
      if (decomp_profiler == decomp_profiler_none) call decomp_profiler_prep()
      ! Start the profiler
      call decomp_profiler_init()
      ! Start the timer for decomp_2d_init
      if (decomp_profiler_d2d) call decomp_profiler_start("decomp_2d_init")
-#endif
 
      call decomp_2d_mpi_init(comm)
 
@@ -154,10 +152,8 @@
      !
      call d2d_listing(iounit)
 
-#ifdef PROFILER
      ! Stop the timer for decomp_2d_init
      if (decomp_profiler_d2d) call decomp_profiler_end("decomp_2d_init")
-#endif
 
      return
   end subroutine decomp_2d_init_ref
@@ -169,9 +165,7 @@
 
      implicit none
 
-#ifdef PROFILER
      if (decomp_profiler_d2d) call decomp_profiler_start("decomp_2d_fin")
-#endif
 
      call decomp_2d_mpi_comm_free(DECOMP_2D_COMM_ROW)
      call decomp_2d_mpi_comm_free(DECOMP_2D_COMM_COL)
@@ -197,11 +191,9 @@
 
      call decomp_2d_mpi_fin()
 
-#ifdef PROFILER
      if (decomp_profiler_d2d) call decomp_profiler_end("decomp_2d_fin")
      ! Finalize the profiler
      call decomp_profiler_fin()
-#endif
 
      return
   end subroutine decomp_2d_finalize_ref

--- a/src/decomp_2d_init_fin.f90
+++ b/src/decomp_2d_init_fin.f90
@@ -28,7 +28,6 @@
 
      ! Prepare the profiler if it was not already prepared
      if (decomp_profiler == decomp_profiler_none) call decomp_profiler_prep()
-
      ! Start the profiler
      call decomp_profiler_init()
      ! Start the timer for decomp_2d_init

--- a/src/decomp_2d_init_fin.f90
+++ b/src/decomp_2d_init_fin.f90
@@ -27,7 +27,14 @@
      logical, dimension(2) :: periodic
 
      ! Prepare the profiler if it was not already prepared
-     if (decomp_profiler == decomp_profiler_none) call decomp_profiler_prep()
+     if (decomp_profiler == decomp_profiler_none) then
+        call decomp_profiler_prep(decomp_profiler, &
+                                  decomp_profiler_transpose, &
+                                  decomp_profiler_io, &
+                                  decomp_profiler_fft, &
+                                  decomp_profiler_d2d)
+     end if
+
      ! Start the profiler
      call decomp_profiler_init()
      ! Start the timer for decomp_2d_init
@@ -193,7 +200,7 @@
 
      if (decomp_profiler_d2d) call decomp_profiler_end("decomp_2d_fin")
      ! Finalize the profiler
-     call decomp_profiler_fin()
+     call decomp_profiler_fin(decomp_profiler)
 
      return
   end subroutine decomp_2d_finalize_ref

--- a/src/fft_cufft.f90
+++ b/src/fft_cufft.f90
@@ -4,9 +4,10 @@
 
 module decomp_2d_fft
 
+   use decomp_2d
    use decomp_2d_constants
    use decomp_2d_mpi
-   use decomp_2d  ! 2D decomposition module
+   use decomp_2d_profiler
    use iso_c_binding
    use cudafor
    use cufft

--- a/src/fft_fftw3.f90
+++ b/src/fft_fftw3.f90
@@ -4,9 +4,10 @@
 
 module decomp_2d_fft
 
+   use decomp_2d
    use decomp_2d_constants
    use decomp_2d_mpi
-   use decomp_2d  ! 2D decomposition module
+   use decomp_2d_profiler
    use iso_c_binding
 
    implicit none

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -5,9 +5,10 @@
 
 module decomp_2d_fft
 
+   use decomp_2d
    use decomp_2d_constants
    use decomp_2d_mpi
-   use decomp_2d  ! 2D decomposition module
+   use decomp_2d_profiler
    use, intrinsic :: iso_c_binding
 
    implicit none

--- a/src/fft_generic.f90
+++ b/src/fft_generic.f90
@@ -5,9 +5,10 @@
 module decomp_2d_fft
 
    use iso_c_binding, only: c_f_pointer, c_loc
+   use decomp_2d
    use decomp_2d_constants
    use decomp_2d_mpi
-   use decomp_2d  ! 2D decomposition module
+   use decomp_2d_profiler
    use glassman
 
    implicit none

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -5,9 +5,10 @@
 module decomp_2d_fft
 
    use iso_c_binding, only: c_f_pointer, c_loc
+   use decomp_2d
    use decomp_2d_constants
    use decomp_2d_mpi
-   use decomp_2d  ! 2D decomposition module
+   use decomp_2d_profiler
    use MKL_DFTI   ! MKL FFT module
 
    implicit none

--- a/src/io.f90
+++ b/src/io.f90
@@ -8,6 +8,7 @@ module decomp_2d_io
    use decomp_2d
    use decomp_2d_constants
    use decomp_2d_mpi
+   use decomp_2d_profiler
    use MPI
 
 #ifdef ADIOS2

--- a/src/log.f90
+++ b/src/log.f90
@@ -192,13 +192,13 @@ contains
 #endif
       write (io_unit, *) '==========================================================='
       write (io_unit, *) 'Profiler id : ', decomp_profiler
-#ifdef PROFILER
       call decomp_profiler_log(io_unit)
-      write (io_unit, *) "   Profiling transpose : ", decomp_profiler_transpose
-      write (io_unit, *) "   Profiling IO : ", decomp_profiler_io
-      write (io_unit, *) "   Profiling FFT : ", decomp_profiler_fft
-      write (io_unit, *) "   Profiling decomp_2d : ", decomp_profiler_d2d
-#endif
+      if (decomp_profiler /= decomp_profiler_none) then
+         write (io_unit, *) "   Profiling transpose : ", decomp_profiler_transpose
+         write (io_unit, *) "   Profiling IO : ", decomp_profiler_io
+         write (io_unit, *) "   Profiling FFT : ", decomp_profiler_fft
+         write (io_unit, *) "   Profiling decomp_2d : ", decomp_profiler_d2d
+      end if
       write (io_unit, *) '==========================================================='
       ! Info about each decomp_info object
       call decomp_info_print(decomp_main, io_unit, "decomp_main")

--- a/src/profiler_caliper.f90
+++ b/src/profiler_caliper.f90
@@ -20,10 +20,11 @@ module decomp_2d_profiler
    !
    integer, save, public :: decomp_profiler = decomp_profiler_none
    ! Default : profile everything
-   logical, save, public :: decomp_profiler_transpose = .true.
-   logical, save, public :: decomp_profiler_io = .true.
-   logical, save, public :: decomp_profiler_fft = .true.
-   logical, save, public :: decomp_profiler_d2d = .true.
+   logical, parameter :: default_profiler = .true.
+   logical, save, public :: decomp_profiler_transpose = default_profiler
+   logical, save, public :: decomp_profiler_io = default_profiler
+   logical, save, public :: decomp_profiler_fft = default_profiler
+   logical, save, public :: decomp_profiler_d2d = default_profiler
 
    ! Caliper object
    type(ConfigManager), save :: mgr
@@ -102,10 +103,10 @@ contains
       call manager_error(mgr)
       call mgr%delete()
       decomp_profiler = decomp_profiler_none
-      decomp_profiler_transpose = .true.
-      decomp_profiler_io = .true.
-      decomp_profiler_fft = .true.
-      decomp_profiler_d2d = .true.
+      decomp_profiler_transpose = default_profiler
+      decomp_profiler_io = default_profiler
+      decomp_profiler_fft = default_profiler
+      decomp_profiler_d2d = default_profiler
 
    end subroutine decomp_profiler_fin_noarg
 

--- a/src/profiler_caliper.f90
+++ b/src/profiler_caliper.f90
@@ -3,7 +3,6 @@
 !
 ! Submodule for the caliper profiler
 !
-#ifdef PROFILER
 submodule(decomp_2d) d2d_profiler_caliper
 
    use caliper_mod, only: ConfigManager, ConfigManager_new, &
@@ -37,6 +36,9 @@ contains
    ! Finalize
    !
    module subroutine decomp_profiler_fin_noarg
+
+      implicit none
+
       call mgr%flush()
       call manager_error(mgr)
       call mgr%stop()
@@ -135,4 +137,3 @@ contains
    end subroutine manager_error
 
 end submodule d2d_profiler_caliper
-#endif

--- a/src/profiler_none.f90
+++ b/src/profiler_none.f90
@@ -1,0 +1,86 @@
+!! SPDX-License-Identifier: BSD-3-Clause
+
+!
+! Dummy submodule when there is no profiler
+!
+submodule(decomp_2d) d2d_profiler_none
+
+   implicit none
+
+contains
+
+   !
+   ! Dummy initialize
+   !
+   module subroutine decomp_profiler_init_noarg
+
+      implicit none
+
+      decomp_profiler = decomp_profiler_none
+
+   end subroutine decomp_profiler_init_noarg
+
+   !
+   ! Dummy finalize
+   !
+   module subroutine decomp_profiler_fin_noarg
+
+      implicit none
+
+      decomp_profiler = decomp_profiler_none
+
+   end subroutine decomp_profiler_fin_noarg
+
+   !
+   ! Dummy log setup
+   !
+   module subroutine decomp_profiler_log_int(io_unit)
+
+      implicit none
+
+      integer, intent(in) :: io_unit
+
+      write (io_unit, *) "No profiling"
+
+   end subroutine decomp_profiler_log_int
+
+   !
+   ! Dummy setup
+   !
+   module subroutine decomp_profiler_prep_bool(profiler_setup)
+
+      implicit none
+
+      logical, dimension(4), intent(in), optional :: profiler_setup
+
+      associate (tmp => profiler_setup); end associate
+
+   end subroutine decomp_profiler_prep_bool
+
+   !
+   ! Dummy start a timer
+   !
+   module subroutine decomp_profiler_start_char(timer_name)
+
+      implicit none
+
+      character(len=*), intent(in) :: timer_name
+
+      associate (tmp => timer_name); end associate
+
+   end subroutine decomp_profiler_start_char
+
+   !
+   ! Dummy stop a timer
+   !
+   module subroutine decomp_profiler_end_char(timer_name)
+
+      implicit none
+
+      character(len=*), intent(in) :: timer_name
+
+      associate (tmp => timer_name); end associate
+
+   end subroutine decomp_profiler_end_char
+
+end submodule d2d_profiler_none

--- a/src/profiler_none.f90
+++ b/src/profiler_none.f90
@@ -1,7 +1,7 @@
 !! SPDX-License-Identifier: BSD-3-Clause
 
 !
-! Dummy submodule when there is no profiler
+! Dummy module when there is no profiler
 !
 module decomp_2d_profiler
 
@@ -16,10 +16,11 @@ module decomp_2d_profiler
    !
    integer, save, public :: decomp_profiler = decomp_profiler_none
    ! Default : profile everything
-   logical, save, public :: decomp_profiler_transpose = .true.
-   logical, save, public :: decomp_profiler_io = .true.
-   logical, save, public :: decomp_profiler_fft = .true.
-   logical, save, public :: decomp_profiler_d2d = .true.
+   logical, parameter :: default_profiler = .false.
+   logical, save, public :: decomp_profiler_transpose = default_profiler
+   logical, save, public :: decomp_profiler_io = default_profiler
+   logical, save, public :: decomp_profiler_fft = default_profiler
+   logical, save, public :: decomp_profiler_d2d = default_profiler
 
    private
 

--- a/src/profiler_none.f90
+++ b/src/profiler_none.f90
@@ -9,6 +9,18 @@ module decomp_2d_profiler
 
    implicit none
 
+   !
+   ! Integer to select the profiling tool
+   !    0 => no profiling, default
+   !    1 => Caliper (https://github.com/LLNL/Caliper)
+   !
+   integer, save, public :: decomp_profiler = decomp_profiler_none
+   ! Default : profile everything
+   logical, save, public :: decomp_profiler_transpose = .true.
+   logical, save, public :: decomp_profiler_io = .true.
+   logical, save, public :: decomp_profiler_fft = .true.
+   logical, save, public :: decomp_profiler_d2d = .true.
+
    private
 
    ! public user routines
@@ -26,7 +38,7 @@ module decomp_2d_profiler
 
    ! Generic interface to finalize the profiler
    interface decomp_profiler_fin
-      module procedure decomp_profiler_fin_int
+      module procedure decomp_profiler_fin_noarg
    end interface decomp_profiler_fin
 
    ! Generic interface for the profiler to log setup
@@ -63,15 +75,13 @@ contains
    !
    ! Dummy finalize
    !
-   subroutine decomp_profiler_fin_int(decomp_profiler)
+   subroutine decomp_profiler_fin_noarg()
 
       implicit none
 
-      integer, intent(out) :: decomp_profiler
-
       decomp_profiler = decomp_profiler_none
 
-   end subroutine decomp_profiler_fin_int
+   end subroutine decomp_profiler_fin_noarg
 
    !
    ! Dummy log setup
@@ -89,20 +99,14 @@ contains
    !
    ! Dummy setup
    !
-   subroutine decomp_profiler_prep_bool(decomp_profiler, b_transpose, b_io, b_fft, b_2d, profiler_setup)
+   subroutine decomp_profiler_prep_bool(profiler_setup)
 
       implicit none
 
-      integer, intent(out) :: decomp_profiler
-      logical, intent(out) :: b_transpose, b_io, b_fft, b_2d
       logical, dimension(4), intent(in), optional :: profiler_setup
 
       decomp_profiler = decomp_profiler_none
 
-      associate (tmp => b_transpose); end associate
-      associate (tmp => b_io); end associate
-      associate (tmp => b_fft); end associate
-      associate (tmp => b_2d); end associate
       associate (tmp => profiler_setup); end associate
 
    end subroutine decomp_profiler_prep_bool

--- a/src/profiler_none.f90
+++ b/src/profiler_none.f90
@@ -1,5 +1,8 @@
 !! SPDX-License-Identifier: BSD-3-Clause
 
+! Preprocessor macro to deal with unused variables
+#define unused(x) associate(tmp => x); end associate
+
 !
 ! Dummy module when there is no profiler
 !
@@ -108,7 +111,7 @@ contains
 
       decomp_profiler = decomp_profiler_none
 
-      associate (tmp => profiler_setup); end associate
+      unused(profiler_setup)
 
    end subroutine decomp_profiler_prep_bool
 
@@ -121,7 +124,7 @@ contains
 
       character(len=*), intent(in) :: timer_name
 
-      associate (tmp => timer_name); end associate
+      unused(timer_name)
 
    end subroutine decomp_profiler_start_char
 
@@ -134,7 +137,7 @@ contains
 
       character(len=*), intent(in) :: timer_name
 
-      associate (tmp => timer_name); end associate
+      unused(timer_name)
 
    end subroutine decomp_profiler_end_char
 

--- a/src/profiler_none.f90
+++ b/src/profiler_none.f90
@@ -3,38 +3,80 @@
 !
 ! Dummy submodule when there is no profiler
 !
-submodule(decomp_2d) d2d_profiler_none
+module decomp_2d_profiler
+
+   use decomp_2d_constants, only: decomp_profiler_none
 
    implicit none
+
+   private
+
+   ! public user routines
+   public :: decomp_profiler_init, &
+             decomp_profiler_fin, &
+             decomp_profiler_prep, &
+             decomp_profiler_log, &
+             decomp_profiler_start, &
+             decomp_profiler_end
+
+   ! Generic interface to initialize the profiler
+   interface decomp_profiler_init
+      module procedure decomp_profiler_init_noarg
+   end interface decomp_profiler_init
+
+   ! Generic interface to finalize the profiler
+   interface decomp_profiler_fin
+      module procedure decomp_profiler_fin_int
+   end interface decomp_profiler_fin
+
+   ! Generic interface for the profiler to log setup
+   interface decomp_profiler_log
+      module procedure decomp_profiler_log_int
+   end interface decomp_profiler_log
+
+   ! Generic interface to prepare the profiler before init.
+   interface decomp_profiler_prep
+      module procedure decomp_profiler_prep_bool
+   end interface decomp_profiler_prep
+
+   ! Generic interface for the profiler to start a given timer
+   interface decomp_profiler_start
+      module procedure decomp_profiler_start_char
+   end interface decomp_profiler_start
+
+   ! Generic interface for the profiler to end a given timer
+   interface decomp_profiler_end
+      module procedure decomp_profiler_end_char
+   end interface decomp_profiler_end
 
 contains
 
    !
    ! Dummy initialize
    !
-   module subroutine decomp_profiler_init_noarg
+   subroutine decomp_profiler_init_noarg()
 
       implicit none
-
-      decomp_profiler = decomp_profiler_none
 
    end subroutine decomp_profiler_init_noarg
 
    !
    ! Dummy finalize
    !
-   module subroutine decomp_profiler_fin_noarg
+   subroutine decomp_profiler_fin_int(decomp_profiler)
 
       implicit none
 
+      integer, intent(out) :: decomp_profiler
+
       decomp_profiler = decomp_profiler_none
 
-   end subroutine decomp_profiler_fin_noarg
+   end subroutine decomp_profiler_fin_int
 
    !
    ! Dummy log setup
    !
-   module subroutine decomp_profiler_log_int(io_unit)
+   subroutine decomp_profiler_log_int(io_unit)
 
       implicit none
 
@@ -47,12 +89,20 @@ contains
    !
    ! Dummy setup
    !
-   module subroutine decomp_profiler_prep_bool(profiler_setup)
+   subroutine decomp_profiler_prep_bool(decomp_profiler, b_transpose, b_io, b_fft, b_2d, profiler_setup)
 
       implicit none
 
+      integer, intent(out) :: decomp_profiler
+      logical, intent(out) :: b_transpose, b_io, b_fft, b_2d
       logical, dimension(4), intent(in), optional :: profiler_setup
 
+      decomp_profiler = decomp_profiler_none
+
+      associate (tmp => b_transpose); end associate
+      associate (tmp => b_io); end associate
+      associate (tmp => b_fft); end associate
+      associate (tmp => b_2d); end associate
       associate (tmp => profiler_setup); end associate
 
    end subroutine decomp_profiler_prep_bool
@@ -60,7 +110,7 @@ contains
    !
    ! Dummy start a timer
    !
-   module subroutine decomp_profiler_start_char(timer_name)
+   subroutine decomp_profiler_start_char(timer_name)
 
       implicit none
 
@@ -73,7 +123,7 @@ contains
    !
    ! Dummy stop a timer
    !
-   module subroutine decomp_profiler_end_char(timer_name)
+   subroutine decomp_profiler_end_char(timer_name)
 
       implicit none
 
@@ -83,4 +133,4 @@ contains
 
    end subroutine decomp_profiler_end_char
 
-end submodule d2d_profiler_none
+end module decomp_2d_profiler


### PR DESCRIPTION
Most of the directives are kept to avoid conflicts with pending PR targeting the FFT backends, IO refactoring and transpose subroutines.