### PR TITLE
Remove unused decomp_info objects ph*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ _e.g._ vX.Y - YYYY-MM-DD and a new "Unreleased" section started above.
 ### Deprecated
 ### Removed
 
+Unused `decomp_info` objects `phg`, `ph1`, `ph2`, `ph3` and `ph4`. See [PR #315](https://github.com/2decomp-fft/2decomp-fft/pull/315).
+
 ## v2.0.1
 
 - See JOSS paper ([10.21105/joss.05813](https://doi.org/10.21105/joss.05813))

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -105,9 +105,6 @@ module decomp_2d
 
    ! main (default) decomposition information for global size nx*ny*nz
    TYPE(DECOMP_INFO), target, save, public :: decomp_main
-   ! FIXME The extra decomp_info objects should be defined in the external code, not here
-   !       Currently keeping them to avoid breaking external codes
-   TYPE(DECOMP_INFO), save, public :: phG, ph1, ph2, ph3, ph4
 
    ! staring/ending index and size of data held by current processor
    ! duplicate 'decomp_main', needed by apps to define data structure

--- a/src/log.f90
+++ b/src/log.f90
@@ -224,11 +224,6 @@ contains
       write (io_unit, *) '==========================================================='
       ! Info about each decomp_info object
       call decomp_info_print(decomp_main, io_unit, "decomp_main")
-      call decomp_info_print(phG, io_unit, "phG")
-      call decomp_info_print(ph1, io_unit, "ph1")
-      call decomp_info_print(ph2, io_unit, "ph2")
-      call decomp_info_print(ph3, io_unit, "ph3")
-      call decomp_info_print(ph4, io_unit, "ph4")
       write (io_unit, *) '==========================================================='
       write (io_unit, *) '==========================================================='
 

--- a/src/log.f90
+++ b/src/log.f90
@@ -3,6 +3,7 @@
 ! This file contains routines easing the output to stdout / log files
 submodule(decomp_2d) d2d_log_submodule
 
+   use iso_fortran_env, only: output_unit
    use decomp_2d_constants
    use decomp_2d_mpi
 
@@ -36,8 +37,6 @@ contains
    ! Get the IO unit for the log
    !
    module function d2d_log_get_unit()
-
-      use iso_fortran_env, only: output_unit
 
       implicit none
 
@@ -93,8 +92,6 @@ contains
    !
    module subroutine d2d_log_close_unit(io_unit)
 
-      use iso_fortran_env, only: output_unit
-
       implicit none
 
       ! Input
@@ -118,7 +115,7 @@ contains
    !
    module subroutine d2d_log(given_io_unit)
 
-      use iso_fortran_env, only: output_unit, compiler_version, compiler_options
+      use iso_fortran_env, only: compiler_version, compiler_options
 
       implicit none
 
@@ -126,16 +123,13 @@ contains
       integer, intent(in), optional :: given_io_unit
 
       ! Local variable
-      integer :: io_unit
-      integer :: version, subversion, ierror
+      integer :: io_unit, version, subversion, ierror
 #ifdef DEBUG
       character(len=512) :: fname
 #endif
 
       ! Output log if needed
-      if (decomp_log == D2D_LOG_QUIET) return
-      if (decomp_log == D2D_LOG_STDOUT .and. nrank /= 0) return
-      if (decomp_log == D2D_LOG_TOFILE .and. nrank /= 0) return
+      if (.not.d2d_log_is_active()) return
 
       ! If no IO unit provided, use stdout
       if (present(given_io_unit)) then
@@ -144,7 +138,7 @@ contains
          io_unit = output_unit
       end if
 
-      ! Header
+      ! Print the header
       write (io_unit, *) '==========================================================='
       write (io_unit, *) '=================== Decomp2D - log ========================'
       write (io_unit, *) '==========================================================='
@@ -223,7 +217,6 @@ contains
          write (io_unit, *) "   Profiling decomp_2d : ", decomp_profiler_d2d
       end if
       write (io_unit, *) '==========================================================='
-      ! Info about each decomp_info object
       call decomp_info_print(decomp_main, io_unit, "decomp_main")
       write (io_unit, *) '==========================================================='
       write (io_unit, *) '==========================================================='

--- a/src/log.f90
+++ b/src/log.f90
@@ -1,5 +1,6 @@
 !! SPDX-License-Identifier: BSD-3-Clause
 
+! This file contains routines easing the output to stdout / log files
 submodule(decomp_2d) d2d_log_submodule
 
    use decomp_2d_constants


### PR DESCRIPTION
The external code should define them directly.

The external code should also adopt a sharper naming convention.