### PR TITLE
 Add support for DCT / DST without periodicity in the FFT backend fftw_f03

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,9 @@ add_subdirectory(grad3d)
 if (IO_BACKEND MATCHES "adios2")
   add_subdirectory(io_adios)
 endif (IO_BACKEND MATCHES "adios2")
+if (FFT_Choice MATCHES "fftw_f03")
+  add_subdirectory(dtt)
+endif()
 
 # Set real/complex tests
 set(COMPLEX_TESTS "OFF" CACHE STRING "Enables complex numbers for tests that support it")

--- a/examples/dtt/CMakeLists.txt
+++ b/examples/dtt/CMakeLists.txt
@@ -1,0 +1,21 @@
+file(GLOB files_dtt_x fftw_f03_dtt_x.f90)
+file(GLOB files_dtt_z fftw_f03_dtt_z.f90)
+
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${FFTW_INCLUDE_DIRS})
+
+add_executable(dtt_x ${files_dtt_x})
+add_executable(dtt_z ${files_dtt_z})
+
+target_link_libraries(dtt_x PRIVATE decomp2d examples_utils)
+target_link_libraries(dtt_z PRIVATE decomp2d examples_utils)
+
+# Run the test(s)
+set(run_dir "${test_dir}/dtt_x")
+message(STATUS "Example dir ${run_dir}")
+file(MAKE_DIRECTORY ${run_dir})
+add_test(NAME dtt_x COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:dtt_x> ${TEST_ARGUMENTS} WORKING_DIRECTORY ${run_dir})
+set(run_dir "${test_dir}/dtt_z")
+message(STATUS "Example dir ${run_dir}")
+file(MAKE_DIRECTORY ${run_dir})
+add_test(NAME dtt_z COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:dtt_z> ${TEST_ARGUMENTS} WORKING_DIRECTORY ${run_dir})

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -202,9 +202,9 @@ program dtt_x
             call MPI_ALLREDUCE(MPI_IN_PLACE, errl2, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
             errl2 = errl2 / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
             call MPI_ALLREDUCE(MPI_IN_PLACE, errli, 1, real_type, MPI_MAX, MPI_COMM_WORLD, ierror)
-            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', errl2, errli
+            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', sqrt(errl2), errli
 
-            if (errl2 > 100*epsilon(errl2)) then
+            if (errli > 100*epsilon(errli)) then
                if (nrank.eq.0) then
                   write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
                   write (*, *) dtt_engine%dtt

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -37,7 +37,7 @@ program dtt_x
    integer :: ierror, j, k, l, ii, jj, kk
    integer :: st1, st2, st3
    integer :: en1, en2, en3
-   real(mytype) :: error
+   real(mytype) :: error, errl2, errli
 
    call MPI_INIT(ierror)
    ! To resize the domain we need to know global number of ranks
@@ -164,7 +164,8 @@ program dtt_x
             end if
 
             ! Check the error
-            error = 0._mytype
+            errl2 = 0._mytype
+            errli = 0._mytype
             ! Local size
             st1 = ph%xst(1) + dtt_engine%dtt(4); en1 = ph%xen(1) - dtt_engine%dtt(7)
             if (ph%xst(2) == 1) then
@@ -190,18 +191,20 @@ program dtt_x
             do kk = st3, en3
                do jj = st2, en2
                   do ii = st1, en1
-                     error = error &
-                           + abs(in_r(ii, jj, kk) - real(ii, mytype) / real(nx, mytype) &
+                     error = abs(in_r(ii, jj, kk) - real(ii, mytype) / real(nx, mytype) &
                                                   * real(jj, mytype) / real(ny, mytype) &
                                                   * real(kk, mytype) / real(nz, mytype))
+                     errl2 = errl2 + error**2
+                     errli = max(errli, error)
                   end do
                end do
             end do
-            call MPI_ALLREDUCE(MPI_IN_PLACE, error, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
-            error = error / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
-            if (nrank.eq.0) write (*, *) 'L2 error / mesh point: ', error, j, k, l
+            call MPI_ALLREDUCE(MPI_IN_PLACE, errl2, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
+            errl2 = errl2 / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
+            call MPI_ALLREDUCE(MPI_IN_PLACE, errli, 1, real_type, MPI_MAX, MPI_COMM_WORLD, ierror)
+            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', errl2, errli
 
-            if (error > 100*epsilon(error)) then
+            if (errl2 > 100*epsilon(errl2)) then
                if (nrank.eq.0) then
                   write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
                   write (*, *) dtt_engine%dtt
@@ -228,4 +231,3 @@ program dtt_x
    call MPI_FINALIZE(ierror)
 
 end program dtt_x
-

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -19,16 +19,16 @@ program dtt_x
    integer :: dttxi, dttxf, dttyi, dttyf, dttzi, dttzf
 
    ! Decomp_info objects in the phuysical and spectral space
-   type(decomp_info), pointer :: ph => null() , sp => null()
+   type(decomp_info), pointer :: ph => null(), sp => null()
    ! Output in case of periodicity
    complex(mytype), target, allocatable, dimension(:, :, :) :: out_c
    ! Ouput when there is no periodicity
    real(mytype), target, allocatable, dimension(:, :, :) :: out_r
    ! Input
    real(mytype), target, allocatable, dimension(:, :, :) :: in_r
-   ! Objects 
+   ! Objects
    type(decomp_2d_fft_engine), target, save :: dtt_engine
- 
+
    ! 3 directions
    ! 9 transforms (periodicity, 4 DCT, 4 DST)
    ! Default values for ifirst, ofirst and ndismiss
@@ -75,17 +75,16 @@ program dtt_x
 
    call decomp_2d_testing_log()
 
-  
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !! Define all combinations
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    do j = 1, 9
-       do k = 1, 9
-          do l =1, 9
-             DTT(:, j, k, l) = (/j-1, k-1, l-1/)
-          end do
-       end do
+      do k = 1, 9
+         do l = 1, 9
+            DTT(:, j, k, l) = (/j - 1, k - 1, l - 1/)
+         end do
+      end do
    end do
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -97,9 +96,9 @@ program dtt_x
          do l = dttzi, dttzf
 
             ! Init the FFT engine
-            call dtt_engine%init(pencil = PHYSICAL_IN_X, &
-                                 nx = nx, ny = ny, nz = nz, &
-                                 opt_DTT = DTT(:, j, k, l))
+            call dtt_engine%init(pencil=PHYSICAL_IN_X, &
+                                 nx=nx, ny=ny, nz=nz, &
+                                 opt_DTT=DTT(:, j, k, l))
             call dtt_engine%use_it()
 
             ! Get the decomp_info objects
@@ -124,8 +123,8 @@ program dtt_x
                do jj = st2, en2
                   do ii = st1, en1
                      in_r(ii, jj, kk) = real(ii, mytype) / real(nx, mytype) &
-                                      * real(jj, mytype) / real(ny, mytype) &
-                                      * real(kk, mytype) / real(nz, mytype)
+                                        * real(jj, mytype) / real(ny, mytype) &
+                                        * real(kk, mytype) / real(nz, mytype)
                   end do
                end do
             end do
@@ -140,29 +139,29 @@ program dtt_x
             if (DTT(1, j, k, l) == 0) then
                in_r = in_r / real(nx, mytype)
             else if (DTT(1, j, k, l) == 1 .or. DTT(1, j, k, l) == 4) then
-               in_r = in_r / real(2*nx-2, mytype)
+               in_r = in_r / real(2 * nx - 2, mytype)
             else if (DTT(1, j, k, l) == 5) then
-               in_r = in_r / real(2*nx+2-2*dtt_engine%dtt(7), mytype)
+               in_r = in_r / real(2 * nx + 2 - 2 * dtt_engine%dtt(7), mytype)
             else
-               in_r = in_r / real(2*nx-2*dtt_engine%dtt(7), mytype)
+               in_r = in_r / real(2 * nx - 2 * dtt_engine%dtt(7), mytype)
             end if
             if (DTT(2, j, k, l) == 0) then
                in_r = in_r / real(ny, mytype)
             else if (DTT(2, j, k, l) == 1 .or. DTT(2, j, k, l) == 4) then
-               in_r = in_r / real(2*ny-2, mytype)
+               in_r = in_r / real(2 * ny - 2, mytype)
             else if (DTT(2, j, k, l) == 5) then
-               in_r = in_r / real(2*ny+2-2*dtt_engine%dtt(8), mytype)
+               in_r = in_r / real(2 * ny + 2 - 2 * dtt_engine%dtt(8), mytype)
             else
-               in_r = in_r / real(2*ny-2*dtt_engine%dtt(8), mytype)
+               in_r = in_r / real(2 * ny - 2 * dtt_engine%dtt(8), mytype)
             end if
             if (DTT(3, j, k, l) == 0) then
                in_r = in_r / real(nz, mytype)
             else if (DTT(3, j, k, l) == 1 .or. DTT(3, j, k, l) == 4) then
-               in_r = in_r / real(2*nz-2, mytype)
+               in_r = in_r / real(2 * nz - 2, mytype)
             else if (DTT(3, j, k, l) == 5) then
-               in_r = in_r / real(2*nz+2-2*dtt_engine%dtt(9), mytype)
+               in_r = in_r / real(2 * nz + 2 - 2 * dtt_engine%dtt(9), mytype)
             else
-               in_r = in_r / real(2*nz-2*dtt_engine%dtt(9), mytype)
+               in_r = in_r / real(2 * nz - 2 * dtt_engine%dtt(9), mytype)
             end if
 
             ! Check the error
@@ -175,12 +174,12 @@ program dtt_x
                st2 = dtt_engine%dtt(5)
             else
                st2 = ph%xst(2)
-            endif
+            end if
             if (ph%xen(2) == ny) then
                en2 = ph%xen(2) - dtt_engine%dtt(8) + dtt_engine%dtt(5) - 1
             else
                en2 = ph%xen(2)
-            endif
+            end if
             if (ph%xst(3) == 1) then
                st3 = dtt_engine%dtt(6)
             else
@@ -195,8 +194,8 @@ program dtt_x
                do jj = st2, en2
                   do ii = st1, en1
                      error = abs(in_r(ii, jj, kk) - real(ii, mytype) / real(nx, mytype) &
-                                                  * real(jj, mytype) / real(ny, mytype) &
-                                                  * real(kk, mytype) / real(nz, mytype))
+                                 * real(jj, mytype) / real(ny, mytype) &
+                                 * real(kk, mytype) / real(nz, mytype))
                      errl2 = errl2 + error**2
                      errli = max(errli, error)
                   end do
@@ -205,10 +204,10 @@ program dtt_x
             call MPI_ALLREDUCE(MPI_IN_PLACE, errl2, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
             errl2 = errl2 / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
             call MPI_ALLREDUCE(MPI_IN_PLACE, errli, 1, real_type, MPI_MAX, MPI_COMM_WORLD, ierror)
-            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', sqrt(errl2), errli
+            if (nrank == 0) write (*, *) 'L2 and Linf error: ', sqrt(errl2), errli
 
-            if (errli > 100*epsilon(errli)) then
-               if (nrank.eq.0) then
+            if (errli > 100 * epsilon(errli)) then
+               if (nrank == 0) then
                   write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
                   write (*, *) dtt_engine%dtt
                   write (*, *) real(in_r(:, st2, st3) * nx * ny * nz, kind=real32)
@@ -217,8 +216,8 @@ program dtt_x
             end if
 
             ! Free memory and objects
-            if (allocated(out_r)) deallocate(out_r)
-            if (allocated(out_c)) deallocate(out_c)
+            if (allocated(out_r)) deallocate (out_r)
+            if (allocated(out_c)) deallocate (out_c)
             deallocate (in_r)
             nullify (sp)
             nullify (ph)

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -20,8 +20,6 @@ program dtt_x
 
    ! Decomp_info objects in the phuysical and spectral space
    type(decomp_info), pointer :: ph => null(), sp => null()
-   ! Output in case of periodicity
-   complex(mytype), target, allocatable, dimension(:, :, :) :: out_c
    ! Ouput when there is no periodicity
    real(mytype), target, allocatable, dimension(:, :, :) :: out_r
    ! Input
@@ -53,19 +51,19 @@ program dtt_x
    ! Now we can check if user put some inputs
    call decomp_2d_testing_init(p_row, p_col, nx, ny, nz, dttxi, dttyi, dttzi)
    if (dttxi == -1) then
-      dttxi = 1
+      dttxi = 2
       dttxf = 9
    else
       dttxf = dttxi
    end if
    if (dttyi == -1) then
-      dttyi = 1
+      dttyi = 2
       dttyf = 9
    else
       dttyf = dttyi
    end if
    if (dttzi == -1) then
-      dttzi = 1
+      dttzi = 2
       dttzf = 9
    else
       dttzf = dttzi
@@ -103,13 +101,11 @@ program dtt_x
 
             ! Get the decomp_info objects
             ph => decomp_2d_fft_get_ph()
-            sp => decomp_2d_fft_get_dtt_sp()
+            sp => ph
 
             ! Allocate memory and set to zero
             call alloc_x(in_r, ph, .true.)
             in_r = 0._mytype
-            call alloc_z(out_c, sp, .true.)
-            out_c = cmplx(0._mytype, 0._mytype, kind=mytype)
             call alloc_z(out_r, sp, .true.)
             out_r = 0._mytype
 
@@ -131,9 +127,9 @@ program dtt_x
 
             ! Perform forward and backward transform once
             ! Forward, real input, real or complex output
-            call decomp_2d_dtt_3d_r2x(in=in_r, out_real=out_r, out_cplx=out_c)
+            call decomp_2d_dtt_3d_r2r(in_r, out_r, DECOMP_2D_FFT_FORWARD)
             ! Backward, real or complex input, real output
-            call decomp_2d_dtt_3d_x2r(in_real=out_r, in_cplx=out_c, out=in_r)
+            call decomp_2d_dtt_3d_r2r(out_r, in_r, DECOMP_2D_FFT_BACKWARD)
 
             ! Rescale
             if (DTT(1, j, k, l) == 0) then
@@ -217,7 +213,6 @@ program dtt_x
 
             ! Free memory and objects
             if (allocated(out_r)) deallocate (out_r)
-            if (allocated(out_c)) deallocate (out_c)
             deallocate (in_r)
             nullify (sp)
             nullify (ph)

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -21,11 +21,11 @@ program dtt_x
    ! Decomp_info objects in the phuysical and spectral space
    type(decomp_info), pointer :: ph => null() , sp => null()
    ! Output in case of periodicity
-   complex(mytype), allocatable, dimension(:, :, :) :: out_c
+   complex(mytype), target, allocatable, dimension(:, :, :) :: out_c
    ! Ouput when there is no periodicity
-   real(mytype), allocatable, dimension(:, :, :) :: out_r
+   real(mytype), target, allocatable, dimension(:, :, :) :: out_r
    ! Input
-   real(mytype), allocatable, dimension(:, :, :) :: in_r
+   real(mytype), target, allocatable, dimension(:, :, :) :: in_r
    ! Objects 
    type(decomp_2d_fft_engine), target, save :: dtt_engine
  

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -104,7 +104,7 @@ program dtt_x
 
             ! Get the decomp_info objects
             ph => decomp_2d_fft_get_ph()
-            sp => dtt_engine%dtt_decomp_sp
+            sp => decomp_2d_fft_get_dtt_sp()
 
             ! Allocate memory and set to zero
             call alloc_x(in_r, ph, .true.)
@@ -131,8 +131,10 @@ program dtt_x
             end do
 
             ! Perform forward and backward transform once
-            call decomp_2d_dtt_3d_r2x(in_r, out_r, out_c)
-            call decomp_2d_dtt_3d_x2r(out_r, out_c, in_r)
+            ! Forward, real input, real or complex output
+            call decomp_2d_dtt_3d_r2x(in=in_r, out_real=out_r, out_cplx=out_c)
+            ! Backward, real or complex input, real output
+            call decomp_2d_dtt_3d_x2r(in_real=out_r, in_cplx=out_c, out=in_r)
 
             ! Rescale
             if (DTT(1, j, k, l) == 0) then
@@ -167,24 +169,25 @@ program dtt_x
             errl2 = 0._mytype
             errli = 0._mytype
             ! Local size
-            st1 = ph%xst(1) + dtt_engine%dtt(4); en1 = ph%xen(1) - dtt_engine%dtt(7)
+            st1 = dtt_engine%dtt(4)
+            en1 = ph%xen(1) - dtt_engine%dtt(7) + dtt_engine%dtt(4) - 1
             if (ph%xst(2) == 1) then
-               st2 = 1 + dtt_engine%dtt(5)
+               st2 = dtt_engine%dtt(5)
             else
                st2 = ph%xst(2)
             endif
             if (ph%xen(2) == ny) then
-               en2 = ph%xen(2) - dtt_engine%dtt(8)
+               en2 = ph%xen(2) - dtt_engine%dtt(8) + dtt_engine%dtt(5) - 1
             else
                en2 = ph%xen(2)
             endif
             if (ph%xst(3) == 1) then
-               st3 = 1 + dtt_engine%dtt(6)
+               st3 = dtt_engine%dtt(6)
             else
                st3 = ph%xst(3)
             end if
             if (ph%xen(3) == nz) then
-               en3 = ph%xen(3) - dtt_engine%dtt(9)
+               en3 = ph%xen(3) - dtt_engine%dtt(9) + dtt_engine%dtt(6) - 1
             else
                en3 = ph%xen(3)
             end if

--- a/examples/dtt/fftw_f03_dtt_x.f90
+++ b/examples/dtt/fftw_f03_dtt_x.f90
@@ -1,0 +1,231 @@
+!! SPDX-License-Identifier: BSD-3-Clause
+
+program dtt_x
+
+   use decomp_2d
+   use decomp_2d_fft
+   use decomp_2d_constants
+   use decomp_2d_mpi
+   use decomp_2d_testing
+   use MPI
+
+   implicit none
+
+   integer, parameter :: nx_base = 8, ny_base = 9, nz_base = 10
+   integer :: nx, ny, nz
+   integer :: p_row = 0, p_col = 0
+   integer :: resize_domain
+   integer :: nranks_tot
+   integer :: dttxi, dttxf, dttyi, dttyf, dttzi, dttzf
+
+   ! Decomp_info objects in the phuysical and spectral space
+   type(decomp_info), pointer :: ph => null() , sp => null()
+   ! Output in case of periodicity
+   complex(mytype), allocatable, dimension(:, :, :) :: out_c
+   ! Ouput when there is no periodicity
+   real(mytype), allocatable, dimension(:, :, :) :: out_r
+   ! Input
+   real(mytype), allocatable, dimension(:, :, :) :: in_r
+   ! Objects 
+   type(decomp_2d_fft_engine), target, save :: dtt_engine
+ 
+   ! 3 directions
+   ! 9 transforms (periodicity, 4 DCT, 4 DST)
+   ! Default values for ifirst, ofirst and ndismiss
+   integer, dimension(3, 9, 9, 9) :: DTT
+
+   integer :: ierror, j, k, l, ii, jj, kk
+   integer :: st1, st2, st3
+   integer :: en1, en2, en3
+   real(mytype) :: error
+
+   call MPI_INIT(ierror)
+   ! To resize the domain we need to know global number of ranks
+   ! This operation is also done as part of decomp_2d_init
+   call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
+   dttxi = -1
+   dttyi = -1
+   dttzi = -1
+   ! Now we can check if user put some inputs
+   call decomp_2d_testing_init(p_row, p_col, nx, ny, nz, dttxi, dttyi, dttzi)
+   if (dttxi == -1) then
+      dttxi = 1
+      dttxf = 9
+   else
+      dttxf = dttxi
+   end if
+   if (dttyi == -1) then
+      dttyi = 1
+      dttyf = 9
+   else
+      dttyf = dttyi
+   end if
+   if (dttzi == -1) then
+      dttzi = 1
+      dttzf = 9
+   else
+      dttzf = dttzi
+   end if
+
+   call decomp_2d_init(nx, ny, nz, p_row, p_col)
+
+   call decomp_2d_testing_log()
+
+  
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !! Define all combinations
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   do j = 1, 9
+       do k = 1, 9
+          do l =1, 9
+             DTT(:, j, k, l) = (/j-1, k-1, l-1/)
+          end do
+       end do
+   end do
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !! Test the dtt/idtt interface
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   do j = dttxi, dttxf
+      do k = dttyi, dttyf
+         do l = dttzi, dttzf
+
+            ! Init the FFT engine
+            call dtt_engine%init(pencil = PHYSICAL_IN_X, &
+                                 nx = nx, ny = ny, nz = nz, &
+                                 opt_DTT = DTT(:, j, k, l))
+            call dtt_engine%use_it()
+
+            ! Get the decomp_info objects
+            ph => decomp_2d_fft_get_ph()
+            sp => dtt_engine%dtt_decomp_sp
+
+            ! Allocate memory and set to zero
+            call alloc_x(in_r, ph, .true.)
+            in_r = 0._mytype
+            call alloc_z(out_c, sp, .true.)
+            out_c = cmplx(0._mytype, 0._mytype, kind=mytype)
+            call alloc_z(out_r, sp, .true.)
+            out_r = 0._mytype
+
+            ! Local size
+            st1 = ph%xst(1); en1 = ph%xen(1)
+            st2 = ph%xst(2); en2 = ph%xen(2)
+            st3 = ph%xst(3); en3 = ph%xen(3)
+
+            ! Set input
+            do kk = st3, en3
+               do jj = st2, en2
+                  do ii = st1, en1
+                     in_r(ii, jj, kk) = real(ii, mytype) / real(nx, mytype) &
+                                      * real(jj, mytype) / real(ny, mytype) &
+                                      * real(kk, mytype) / real(nz, mytype)
+                  end do
+               end do
+            end do
+
+            ! Perform forward and backward transform once
+            call decomp_2d_dtt_3d_r2x(in_r, out_r, out_c)
+            call decomp_2d_dtt_3d_x2r(out_r, out_c, in_r)
+
+            ! Rescale
+            if (DTT(1, j, k, l) == 0) then
+               in_r = in_r / real(nx, mytype)
+            else if (DTT(1, j, k, l) == 1 .or. DTT(1, j, k, l) == 4) then
+               in_r = in_r / real(2*nx-2, mytype)
+            else if (DTT(1, j, k, l) == 5) then
+               in_r = in_r / real(2*nx+2-2*dtt_engine%dtt(7), mytype)
+            else
+               in_r = in_r / real(2*nx-2*dtt_engine%dtt(7), mytype)
+            end if
+            if (DTT(2, j, k, l) == 0) then
+               in_r = in_r / real(ny, mytype)
+            else if (DTT(2, j, k, l) == 1 .or. DTT(2, j, k, l) == 4) then
+               in_r = in_r / real(2*ny-2, mytype)
+            else if (DTT(2, j, k, l) == 5) then
+               in_r = in_r / real(2*ny+2-2*dtt_engine%dtt(8), mytype)
+            else
+               in_r = in_r / real(2*ny-2*dtt_engine%dtt(8), mytype)
+            end if
+            if (DTT(3, j, k, l) == 0) then
+               in_r = in_r / real(nz, mytype)
+            else if (DTT(3, j, k, l) == 1 .or. DTT(3, j, k, l) == 4) then
+               in_r = in_r / real(2*nz-2, mytype)
+            else if (DTT(3, j, k, l) == 5) then
+               in_r = in_r / real(2*nz+2-2*dtt_engine%dtt(9), mytype)
+            else
+               in_r = in_r / real(2*nz-2*dtt_engine%dtt(9), mytype)
+            end if
+
+            ! Check the error
+            error = 0._mytype
+            ! Local size
+            st1 = ph%xst(1) + dtt_engine%dtt(4); en1 = ph%xen(1) - dtt_engine%dtt(7)
+            if (ph%xst(2) == 1) then
+               st2 = 1 + dtt_engine%dtt(5)
+            else
+               st2 = ph%xst(2)
+            endif
+            if (ph%xen(2) == ny) then
+               en2 = ph%xen(2) - dtt_engine%dtt(8)
+            else
+               en2 = ph%xen(2)
+            endif
+            if (ph%xst(3) == 1) then
+               st3 = 1 + dtt_engine%dtt(6)
+            else
+               st3 = ph%xst(3)
+            end if
+            if (ph%xen(3) == nz) then
+               en3 = ph%xen(3) - dtt_engine%dtt(9)
+            else
+               en3 = ph%xen(3)
+            end if
+            do kk = st3, en3
+               do jj = st2, en2
+                  do ii = st1, en1
+                     error = error &
+                           + abs(in_r(ii, jj, kk) - real(ii, mytype) / real(nx, mytype) &
+                                                  * real(jj, mytype) / real(ny, mytype) &
+                                                  * real(kk, mytype) / real(nz, mytype))
+                  end do
+               end do
+            end do
+            call MPI_ALLREDUCE(MPI_IN_PLACE, error, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
+            error = error / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
+            if (nrank.eq.0) write (*, *) 'L2 error / mesh point: ', error, j, k, l
+
+            if (error > 100*epsilon(error)) then
+               if (nrank.eq.0) then
+                  write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
+                  write (*, *) dtt_engine%dtt
+                  write (*, *) real(in_r(:, st2, st3) * nx * ny * nz, kind=real32)
+               end if
+               call decomp_2d_abort(__FILE__, __LINE__, 1, "DTT: Error above limit")
+            end if
+
+            ! Free memory and objects
+            if (allocated(out_r)) deallocate(out_r)
+            if (allocated(out_c)) deallocate(out_c)
+            deallocate (in_r)
+            nullify (sp)
+            nullify (ph)
+
+            ! Clear the FFT engine
+            call dtt_engine%fin()
+
+         end do
+      end do
+   end do
+
+   call decomp_2d_finalize
+   call MPI_FINALIZE(ierror)
+
+end program dtt_x
+

--- a/examples/dtt/fftw_f03_dtt_z.f90
+++ b/examples/dtt/fftw_f03_dtt_z.f90
@@ -20,8 +20,6 @@ program dtt_z
 
    ! Decomp_info objects in the phuysical and spectral space
    type(decomp_info), pointer :: ph => null(), sp => null()
-   ! Output in case of periodicity
-   complex(mytype), target, allocatable, dimension(:, :, :) :: out_c
    ! Ouput when there is no periodicity
    real(mytype), target, allocatable, dimension(:, :, :) :: out_r
    ! Input
@@ -53,19 +51,19 @@ program dtt_z
    ! Now we can check if user put some inputs
    call decomp_2d_testing_init(p_row, p_col, nx, ny, nz, dttxi, dttyi, dttzi)
    if (dttxi == -1) then
-      dttxi = 1
+      dttxi = 2
       dttxf = 9
    else
       dttxf = dttxi
    end if
    if (dttyi == -1) then
-      dttyi = 1
+      dttyi = 2
       dttyf = 9
    else
       dttyf = dttyi
    end if
    if (dttzi == -1) then
-      dttzi = 1
+      dttzi = 2
       dttzf = 9
    else
       dttzf = dttzi
@@ -103,13 +101,11 @@ program dtt_z
 
             ! Get the decomp_info objects
             ph => decomp_2d_fft_get_ph()
-            sp => decomp_2d_fft_get_dtt_sp()
+            sp => ph
 
             ! Allocate memory and set to zero
             call alloc_z(in_r, ph, .true.)
             in_r = 0._mytype
-            call alloc_x(out_c, sp, .true.)
-            out_c = cmplx(0._mytype, 0._mytype, kind=mytype)
             call alloc_x(out_r, sp, .true.)
             out_r = 0._mytype
 
@@ -131,9 +127,9 @@ program dtt_z
 
             ! Perform forward and backward transform once
             ! Forward, real input, real or complex output
-            call decomp_2d_dtt_3d_r2x(in=in_r, out_real=out_r, out_cplx=out_c)
+            call decomp_2d_dtt_3d_r2r(in_r, out_r, DECOMP_2D_FFT_FORWARD)
             ! Backward, real or complex input, real output
-            call decomp_2d_dtt_3d_x2r(in_real=out_r, in_cplx=out_c, out=in_r)
+            call decomp_2d_dtt_3d_r2r(out_r, in_r, DECOMP_2D_FFT_BACKWARD)
 
             ! Rescale
             if (DTT(1, j, k, l) == 0) then
@@ -217,7 +213,6 @@ program dtt_z
 
             ! Free memory and objects
             if (allocated(out_r)) deallocate (out_r)
-            if (allocated(out_c)) deallocate (out_c)
             deallocate (in_r)
             nullify (sp)
             nullify (ph)

--- a/examples/dtt/fftw_f03_dtt_z.f90
+++ b/examples/dtt/fftw_f03_dtt_z.f90
@@ -19,16 +19,16 @@ program dtt_z
    integer :: dttxi, dttxf, dttyi, dttyf, dttzi, dttzf
 
    ! Decomp_info objects in the phuysical and spectral space
-   type(decomp_info), pointer :: ph => null() , sp => null()
+   type(decomp_info), pointer :: ph => null(), sp => null()
    ! Output in case of periodicity
    complex(mytype), target, allocatable, dimension(:, :, :) :: out_c
    ! Ouput when there is no periodicity
    real(mytype), target, allocatable, dimension(:, :, :) :: out_r
    ! Input
    real(mytype), target, allocatable, dimension(:, :, :) :: in_r
-   ! Objects 
+   ! Objects
    type(decomp_2d_fft_engine), target, save :: dtt_engine
- 
+
    ! 3 directions
    ! 9 transforms (periodicity, 4 DCT, 4 DST)
    ! Default values for ifirst, ofirst and ndismiss
@@ -75,17 +75,16 @@ program dtt_z
 
    call decomp_2d_testing_log()
 
-  
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !! Define all combinations
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    do j = 1, 9
-       do k = 1, 9
-          do l =1, 9
-             DTT(:, j, k, l) = (/j-1, k-1, l-1/)
-          end do
-       end do
+      do k = 1, 9
+         do l = 1, 9
+            DTT(:, j, k, l) = (/j - 1, k - 1, l - 1/)
+         end do
+      end do
    end do
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -97,9 +96,9 @@ program dtt_z
          do l = dttzi, dttzf
 
             ! Init the FFT engine
-            call dtt_engine%init(pencil = PHYSICAL_IN_Z, &
-                                 nx = nx, ny = ny, nz = nz, &
-                                 opt_DTT = DTT(:, j, k, l))
+            call dtt_engine%init(pencil=PHYSICAL_IN_Z, &
+                                 nx=nx, ny=ny, nz=nz, &
+                                 opt_DTT=DTT(:, j, k, l))
             call dtt_engine%use_it()
 
             ! Get the decomp_info objects
@@ -124,8 +123,8 @@ program dtt_z
                do jj = st2, en2
                   do ii = st1, en1
                      in_r(ii, jj, kk) = real(ii, mytype) / real(nx, mytype) &
-                                      * real(jj, mytype) / real(ny, mytype) &
-                                      * real(kk, mytype) / real(nz, mytype)
+                                        * real(jj, mytype) / real(ny, mytype) &
+                                        * real(kk, mytype) / real(nz, mytype)
                   end do
                end do
             end do
@@ -140,29 +139,29 @@ program dtt_z
             if (DTT(1, j, k, l) == 0) then
                in_r = in_r / real(nx, mytype)
             else if (DTT(1, j, k, l) == 1 .or. DTT(1, j, k, l) == 4) then
-               in_r = in_r / real(2*nx-2, mytype)
+               in_r = in_r / real(2 * nx - 2, mytype)
             else if (DTT(1, j, k, l) == 5) then
-               in_r = in_r / real(2*nx+2-2*dtt_engine%dtt(7), mytype)
+               in_r = in_r / real(2 * nx + 2 - 2 * dtt_engine%dtt(7), mytype)
             else
-               in_r = in_r / real(2*nx-2*dtt_engine%dtt(7), mytype)
+               in_r = in_r / real(2 * nx - 2 * dtt_engine%dtt(7), mytype)
             end if
             if (DTT(2, j, k, l) == 0) then
                in_r = in_r / real(ny, mytype)
             else if (DTT(2, j, k, l) == 1 .or. DTT(2, j, k, l) == 4) then
-               in_r = in_r / real(2*ny-2, mytype)
+               in_r = in_r / real(2 * ny - 2, mytype)
             else if (DTT(2, j, k, l) == 5) then
-               in_r = in_r / real(2*ny+2-2*dtt_engine%dtt(8), mytype)
+               in_r = in_r / real(2 * ny + 2 - 2 * dtt_engine%dtt(8), mytype)
             else
-               in_r = in_r / real(2*ny-2*dtt_engine%dtt(8), mytype)
+               in_r = in_r / real(2 * ny - 2 * dtt_engine%dtt(8), mytype)
             end if
             if (DTT(3, j, k, l) == 0) then
                in_r = in_r / real(nz, mytype)
             else if (DTT(3, j, k, l) == 1 .or. DTT(3, j, k, l) == 4) then
-               in_r = in_r / real(2*nz-2, mytype)
+               in_r = in_r / real(2 * nz - 2, mytype)
             else if (DTT(3, j, k, l) == 5) then
-               in_r = in_r / real(2*nz+2-2*dtt_engine%dtt(9), mytype)
+               in_r = in_r / real(2 * nz + 2 - 2 * dtt_engine%dtt(9), mytype)
             else
-               in_r = in_r / real(2*nz-2*dtt_engine%dtt(9), mytype)
+               in_r = in_r / real(2 * nz - 2 * dtt_engine%dtt(9), mytype)
             end if
 
             ! Check the error
@@ -183,20 +182,20 @@ program dtt_z
                st2 = dtt_engine%dtt(5)
             else
                st2 = ph%zst(2)
-            endif
+            end if
             if (ph%zen(2) == ny) then
                en2 = ph%zen(2) - dtt_engine%dtt(8) + dtt_engine%dtt(5) - 1
             else
                en2 = ph%zen(2)
-            endif
+            end if
             st3 = dtt_engine%dtt(6)
             en3 = ph%zen(3) - dtt_engine%dtt(9) + dtt_engine%dtt(6) - 1
             do kk = st3, en3
                do jj = st2, en2
                   do ii = st1, en1
                      error = abs(in_r(ii, jj, kk) - real(ii, mytype) / real(nx, mytype) &
-                                                  * real(jj, mytype) / real(ny, mytype) &
-                                                  * real(kk, mytype) / real(nz, mytype))
+                                 * real(jj, mytype) / real(ny, mytype) &
+                                 * real(kk, mytype) / real(nz, mytype))
                      errl2 = errl2 + error**2
                      errli = max(errli, error)
                   end do
@@ -205,10 +204,10 @@ program dtt_z
             call MPI_ALLREDUCE(MPI_IN_PLACE, errl2, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
             errl2 = errl2 / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
             call MPI_ALLREDUCE(MPI_IN_PLACE, errli, 1, real_type, MPI_MAX, MPI_COMM_WORLD, ierror)
-            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', sqrt(errl2), errli
+            if (nrank == 0) write (*, *) 'L2 and Linf error: ', sqrt(errl2), errli
 
-            if (errli > 100*epsilon(errli)) then
-               if (nrank.eq.0) then
+            if (errli > 100 * epsilon(errli)) then
+               if (nrank == 0) then
                   write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
                   write (*, *) dtt_engine%dtt
                   write (*, *) real(in_r(:, st2, st3) * nx * ny * nz, kind=real32)
@@ -217,8 +216,8 @@ program dtt_z
             end if
 
             ! Free memory and objects
-            if (allocated(out_r)) deallocate(out_r)
-            if (allocated(out_c)) deallocate(out_c)
+            if (allocated(out_r)) deallocate (out_r)
+            if (allocated(out_c)) deallocate (out_c)
             deallocate (in_r)
             nullify (sp)
             nullify (ph)

--- a/examples/dtt/fftw_f03_dtt_z.f90
+++ b/examples/dtt/fftw_f03_dtt_z.f90
@@ -202,9 +202,9 @@ program dtt_z
             call MPI_ALLREDUCE(MPI_IN_PLACE, errl2, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
             errl2 = errl2 / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
             call MPI_ALLREDUCE(MPI_IN_PLACE, errli, 1, real_type, MPI_MAX, MPI_COMM_WORLD, ierror)
-            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', errl2, errli
+            if (nrank.eq.0) write (*, *) 'L2 and Linf error: ', sqrt(errl2), errli
 
-            if (errl2 > 100*epsilon(errl2)) then
+            if (errli > 100*epsilon(errli)) then
                if (nrank.eq.0) then
                   write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
                   write (*, *) dtt_engine%dtt

--- a/examples/dtt/fftw_f03_dtt_z.f90
+++ b/examples/dtt/fftw_f03_dtt_z.f90
@@ -104,7 +104,7 @@ program dtt_z
 
             ! Get the decomp_info objects
             ph => decomp_2d_fft_get_ph()
-            sp => dtt_engine%dtt_decomp_sp
+            sp => decomp_2d_fft_get_dtt_sp()
 
             ! Allocate memory and set to zero
             call alloc_z(in_r, ph, .true.)
@@ -131,8 +131,10 @@ program dtt_z
             end do
 
             ! Perform forward and backward transform once
-            call decomp_2d_dtt_3d_r2x(in_r, out_r, out_c)
-            call decomp_2d_dtt_3d_x2r(out_r, out_c, in_r)
+            ! Forward, real input, real or complex output
+            call decomp_2d_dtt_3d_r2x(in=in_r, out_real=out_r, out_cplx=out_c)
+            ! Backward, real or complex input, real output
+            call decomp_2d_dtt_3d_x2r(in_real=out_r, in_cplx=out_c, out=in_r)
 
             ! Rescale
             if (DTT(1, j, k, l) == 0) then
@@ -167,27 +169,28 @@ program dtt_z
             errl2 = 0._mytype
             errli = 0._mytype
             ! Local size
-            st1 = ph%zst(1) + dtt_engine%dtt(4); en1 = ph%zen(1) - dtt_engine%dtt(7)
+            if (ph%zst(1) == 1) then
+               st1 = dtt_engine%dtt(4)
+            else
+               st1 = ph%zst(1)
+            end if
+            if (ph%zen(1) == nx) then
+               en1 = ph%zen(1) - dtt_engine%dtt(7) + dtt_engine%dtt(4) - 1
+            else
+               en1 = ph%zen(1)
+            end if
             if (ph%zst(2) == 1) then
-               st2 = 1 + dtt_engine%dtt(5)
+               st2 = dtt_engine%dtt(5)
             else
                st2 = ph%zst(2)
             endif
             if (ph%zen(2) == ny) then
-               en2 = ph%zen(2) - dtt_engine%dtt(8)
+               en2 = ph%zen(2) - dtt_engine%dtt(8) + dtt_engine%dtt(5) - 1
             else
                en2 = ph%zen(2)
             endif
-            if (ph%zst(3) == 1) then
-               st3 = 1 + dtt_engine%dtt(6)
-            else
-               st3 = ph%zst(3)
-            end if
-            if (ph%zen(3) == nz) then
-               en3 = ph%zen(3) - dtt_engine%dtt(9)
-            else
-               en3 = ph%zen(3)
-            end if
+            st3 = dtt_engine%dtt(6)
+            en3 = ph%zen(3) - dtt_engine%dtt(9) + dtt_engine%dtt(6) - 1
             do kk = st3, en3
                do jj = st2, en2
                   do ii = st1, en1

--- a/examples/dtt/fftw_f03_dtt_z.f90
+++ b/examples/dtt/fftw_f03_dtt_z.f90
@@ -21,11 +21,11 @@ program dtt_z
    ! Decomp_info objects in the phuysical and spectral space
    type(decomp_info), pointer :: ph => null() , sp => null()
    ! Output in case of periodicity
-   complex(mytype), allocatable, dimension(:, :, :) :: out_c
+   complex(mytype), target, allocatable, dimension(:, :, :) :: out_c
    ! Ouput when there is no periodicity
-   real(mytype), allocatable, dimension(:, :, :) :: out_r
+   real(mytype), target, allocatable, dimension(:, :, :) :: out_r
    ! Input
-   real(mytype), allocatable, dimension(:, :, :) :: in_r
+   real(mytype), target, allocatable, dimension(:, :, :) :: in_r
    ! Objects 
    type(decomp_2d_fft_engine), target, save :: dtt_engine
  

--- a/examples/dtt/fftw_f03_dtt_z.f90
+++ b/examples/dtt/fftw_f03_dtt_z.f90
@@ -1,0 +1,230 @@
+!! SPDX-License-Identifier: BSD-3-Clause
+
+program dtt_z
+
+   use decomp_2d
+   use decomp_2d_fft
+   use decomp_2d_constants
+   use decomp_2d_mpi
+   use decomp_2d_testing
+   use MPI
+
+   implicit none
+
+   integer, parameter :: nx_base = 8, ny_base = 9, nz_base = 10
+   integer :: nx, ny, nz
+   integer :: p_row = 0, p_col = 0
+   integer :: resize_domain
+   integer :: nranks_tot
+   integer :: dttxi, dttxf, dttyi, dttyf, dttzi, dttzf
+
+   ! Decomp_info objects in the phuysical and spectral space
+   type(decomp_info), pointer :: ph => null() , sp => null()
+   ! Output in case of periodicity
+   complex(mytype), allocatable, dimension(:, :, :) :: out_c
+   ! Ouput when there is no periodicity
+   real(mytype), allocatable, dimension(:, :, :) :: out_r
+   ! Input
+   real(mytype), allocatable, dimension(:, :, :) :: in_r
+   ! Objects 
+   type(decomp_2d_fft_engine), target, save :: dtt_engine
+ 
+   ! 3 directions
+   ! 9 transforms (periodicity, 4 DCT, 4 DST)
+   ! Default values for ifirst, ofirst and ndismiss
+   integer, dimension(3, 9, 9, 9) :: DTT
+
+   integer :: ierror, j, k, l, ii, jj, kk
+   integer :: st1, st2, st3
+   integer :: en1, en2, en3
+   real(mytype) :: error
+
+   call MPI_INIT(ierror)
+   ! To resize the domain we need to know global number of ranks
+   ! This operation is also done as part of decomp_2d_init
+   call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
+   dttxi = -1
+   dttyi = -1
+   dttzi = -1
+   ! Now we can check if user put some inputs
+   call decomp_2d_testing_init(p_row, p_col, nx, ny, nz, dttxi, dttyi, dttzi)
+   if (dttxi == -1) then
+      dttxi = 1
+      dttxf = 9
+   else
+      dttxf = dttxi
+   end if
+   if (dttyi == -1) then
+      dttyi = 1
+      dttyf = 9
+   else
+      dttyf = dttyi
+   end if
+   if (dttzi == -1) then
+      dttzi = 1
+      dttzf = 9
+   else
+      dttzf = dttzi
+   end if
+
+   call decomp_2d_init(nx, ny, nz, p_row, p_col)
+
+   call decomp_2d_testing_log()
+
+  
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !! Define all combinations
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   do j = 1, 9
+       do k = 1, 9
+          do l =1, 9
+             DTT(:, j, k, l) = (/j-1, k-1, l-1/)
+          end do
+       end do
+   end do
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   !! Test the dtt/idtt interface
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+   do j = dttxi, dttxf
+      do k = dttyi, dttyf
+         do l = dttzi, dttzf
+
+            ! Init the FFT engine
+            call dtt_engine%init(pencil = PHYSICAL_IN_Z, &
+                                 nx = nx, ny = ny, nz = nz, &
+                                 opt_DTT = DTT(:, j, k, l))
+            call dtt_engine%use_it()
+
+            ! Get the decomp_info objects
+            ph => decomp_2d_fft_get_ph()
+            sp => dtt_engine%dtt_decomp_sp
+
+            ! Allocate memory and set to zero
+            call alloc_z(in_r, ph, .true.)
+            in_r = 0._mytype
+            call alloc_x(out_c, sp, .true.)
+            out_c = cmplx(0._mytype, 0._mytype, kind=mytype)
+            call alloc_x(out_r, sp, .true.)
+            out_r = 0._mytype
+
+            ! Local size
+            st1 = ph%zst(1); en1 = ph%zen(1)
+            st2 = ph%zst(2); en2 = ph%zen(2)
+            st3 = ph%zst(3); en3 = ph%zen(3)
+
+            ! Set input
+            do kk = st3, en3
+               do jj = st2, en2
+                  do ii = st1, en1
+                     in_r(ii, jj, kk) = real(ii, mytype) / real(nx, mytype) &
+                                      * real(jj, mytype) / real(ny, mytype) &
+                                      * real(kk, mytype) / real(nz, mytype)
+                  end do
+               end do
+            end do
+
+            ! Perform forward and backward transform once
+            call decomp_2d_dtt_3d_r2x(in_r, out_r, out_c)
+            call decomp_2d_dtt_3d_x2r(out_r, out_c, in_r)
+
+            ! Rescale
+            if (DTT(1, j, k, l) == 0) then
+               in_r = in_r / real(nx, mytype)
+            else if (DTT(1, j, k, l) == 1 .or. DTT(1, j, k, l) == 4) then
+               in_r = in_r / real(2*nx-2, mytype)
+            else if (DTT(1, j, k, l) == 5) then
+               in_r = in_r / real(2*nx+2-2*dtt_engine%dtt(7), mytype)
+            else
+               in_r = in_r / real(2*nx-2*dtt_engine%dtt(7), mytype)
+            end if
+            if (DTT(2, j, k, l) == 0) then
+               in_r = in_r / real(ny, mytype)
+            else if (DTT(2, j, k, l) == 1 .or. DTT(2, j, k, l) == 4) then
+               in_r = in_r / real(2*ny-2, mytype)
+            else if (DTT(2, j, k, l) == 5) then
+               in_r = in_r / real(2*ny+2-2*dtt_engine%dtt(8), mytype)
+            else
+               in_r = in_r / real(2*ny-2*dtt_engine%dtt(8), mytype)
+            end if
+            if (DTT(3, j, k, l) == 0) then
+               in_r = in_r / real(nz, mytype)
+            else if (DTT(3, j, k, l) == 1 .or. DTT(3, j, k, l) == 4) then
+               in_r = in_r / real(2*nz-2, mytype)
+            else if (DTT(3, j, k, l) == 5) then
+               in_r = in_r / real(2*nz+2-2*dtt_engine%dtt(9), mytype)
+            else
+               in_r = in_r / real(2*nz-2*dtt_engine%dtt(9), mytype)
+            end if
+
+            ! Check the error
+            error = 0._mytype
+            ! Local size
+            st1 = ph%zst(1) + dtt_engine%dtt(4); en1 = ph%zen(1) - dtt_engine%dtt(7)
+            if (ph%zst(2) == 1) then
+               st2 = 1 + dtt_engine%dtt(5)
+            else
+               st2 = ph%zst(2)
+            endif
+            if (ph%zen(2) == ny) then
+               en2 = ph%zen(2) - dtt_engine%dtt(8)
+            else
+               en2 = ph%zen(2)
+            endif
+            if (ph%zst(3) == 1) then
+               st3 = 1 + dtt_engine%dtt(6)
+            else
+               st3 = ph%zst(3)
+            end if
+            if (ph%zen(3) == nz) then
+               en3 = ph%zen(3) - dtt_engine%dtt(9)
+            else
+               en3 = ph%zen(3)
+            end if
+            do kk = st3, en3
+               do jj = st2, en2
+                  do ii = st1, en1
+                     error = error &
+                           + abs(in_r(ii, jj, kk) - real(ii, mytype) / real(nx, mytype) &
+                                                  * real(jj, mytype) / real(ny, mytype) &
+                                                  * real(kk, mytype) / real(nz, mytype))
+                  end do
+               end do
+            end do
+            call MPI_ALLREDUCE(MPI_IN_PLACE, error, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
+            error = error / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
+            if (nrank.eq.0) write (*, *) 'L2 error / mesh point: ', error, j, k, l
+
+            if (error > 100*epsilon(error)) then
+               if (nrank.eq.0) then
+                  write (*, *) "check case ", j, k, l, DTT(:, j, k, l)
+                  write (*, *) dtt_engine%dtt
+                  write (*, *) real(in_r(:, st2, st3) * nx * ny * nz, kind=real32)
+               end if
+               call decomp_2d_abort(__FILE__, __LINE__, 1, "DTT: Error above limit")
+            end if
+
+            ! Free memory and objects
+            if (allocated(out_r)) deallocate(out_r)
+            if (allocated(out_c)) deallocate(out_c)
+            deallocate (in_r)
+            nullify (sp)
+            nullify (ph)
+
+            ! Clear the FFT engine
+            call dtt_engine%fin()
+
+         end do
+      end do
+   end do
+
+   call decomp_2d_finalize
+   call MPI_FINALIZE(ierror)
+
+end program dtt_z

--- a/examples/utilities.f90
+++ b/examples/utilities.f90
@@ -17,6 +17,7 @@ module decomp_2d_testing
       module procedure decomp_2d_testing_init_2int
       module procedure decomp_2d_testing_init_5int
       module procedure decomp_2d_testing_init_6int
+      module procedure decomp_2d_testing_init_8int
    end interface decomp_2d_testing_init
 
 contains
@@ -130,6 +131,50 @@ contains
       end if
 
    end subroutine decomp_2d_testing_init_6int
+
+   !
+   ! Process command-line arguments, 8 integers
+   !
+   subroutine decomp_2d_testing_init_8int(p_row, p_col, nx, ny, nz, dttx, dtty, dttz)
+
+      implicit none
+
+      integer, intent(inout) :: p_row, p_col, nx, ny, nz, dttx, dtty, dttz
+
+      integer :: arg, nargin, DecInd, status, FNLength
+      character(len=80) :: InputFN
+
+      nargin = command_argument_count()
+
+      if (nargin == 0) return
+
+      if (nargin == 2 .or. nargin == 5 .or. nargin == 8) then
+         do arg = 1, nargin
+            call get_command_argument(arg, InputFN, FNLength, status)
+            read (InputFN, *, iostat=status) DecInd
+            if (arg == 1) then
+               p_row = DecInd
+            elseif (arg == 2) then
+               p_col = DecInd
+            elseif (arg == 3) then
+               nx = DecInd
+            elseif (arg == 4) then
+               ny = DecInd
+            elseif (arg == 5) then
+               nz = DecInd
+            elseif (arg == 6) then
+               dttx = DecInd
+            elseif (arg == 7) then
+               dtty = DecInd
+            elseif (arg == 8) then
+               dttz = DecInd
+            end if
+         end do
+      else
+         use_default = .true.
+      end if
+
+   end subroutine decomp_2d_testing_init_8int
 
    !
    ! Print some warning if the input was incorrect

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -2085,7 +2085,7 @@ contains
 #ifdef DOUBLE_PREC
       plan = fftw_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), &
 #else
-      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), &
+      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), & !&
 #endif
                                  a1, decomp%xsz(1), 1, decomp%xsz(1), &
                                  a2, decomp%xsz(1), 1, decomp%xsz(1), &

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -1966,16 +1966,16 @@ contains
       ! Local variables
 #ifdef DOUBLE_PREC
       real(C_DOUBLE), allocatable, target :: a1(:, :, :)
-      real(C_DOUBLE), allocatable, target :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
 #else
       real(C_FLOAT), allocatable, target :: a1(:, :, :)
-      real(C_FLOAT), allocatable, target :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
 #endif
       integer(C_INT) :: ntmp(1)
       integer(C_FFTW_R2R_KIND) :: tmp(1)
 
       call alloc_x(a1, decomp)
-      call alloc_x(a2, decomp)
+      a2 => a1
 
       ntmp(1) = decomp%xsz(1) - ndismiss
       tmp(1) = dtt
@@ -1989,7 +1989,7 @@ contains
                                  tmp(1), plan_type_dtt)
 
       deallocate(a1)
-      deallocate(a2)
+      nullify (a2)
       if (.not. c_associated(plan)) call decomp_2d_abort(__FILE__, __LINE__, 17, "Plan creation failed")
 
    end subroutine r2r_1m_x_plan
@@ -2007,16 +2007,16 @@ contains
       ! Local variables
 #ifdef DOUBLE_PREC
       real(C_DOUBLE), allocatable, target :: a1(:, :, :)
-      real(C_DOUBLE), allocatable, target :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
 #else
       real(C_FLOAT), allocatable, target :: a1(:, :, :)
-      real(C_FLOAT), allocatable, target :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
 #endif
       integer(C_INT) :: ntmp(1)
       integer(C_FFTW_R2R_KIND) :: tmp(1)
 
       allocate(a1(decomp%ysz(1), decomp%ysz(2), 1))
-      allocate(a2(decomp%ysz(1), decomp%ysz(2), 1))
+      a2 => a1
 
       ntmp(1) = decomp%ysz(2) - ndismiss
       tmp(1) = dtt
@@ -2029,8 +2029,8 @@ contains
                                  a2, decomp%ysz(2), decomp%ysz(1), 1, &
                                  tmp(1), plan_type_dtt)
 
-      deallocate(a1)
-      deallocate(a2)
+      deallocate (a1)
+      nullify (a2)
       if (.not. c_associated(plan)) call decomp_2d_abort(__FILE__, __LINE__, 18, "Plan creation failed")
 
    end subroutine r2r_1m_y_plan
@@ -2048,16 +2048,16 @@ contains
       ! Local variables
 #ifdef DOUBLE_PREC
       real(C_DOUBLE), allocatable, target :: a1(:, :, :)
-      real(C_DOUBLE), allocatable, target :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
 #else
       real(C_FLOAT), allocatable, target :: a1(:, :, :)
-      real(C_FLOAT), allocatable, target :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
 #endif
       integer(C_INT) :: ntmp(1)
       integer(C_FFTW_R2R_KIND) :: tmp(1)
 
       call alloc_z(a1, decomp)
-      call alloc_z(a2, decomp)
+      a2 => a1
 
       ntmp(1) = decomp%zsz(3) - ndismiss
       tmp(1) = dtt
@@ -2071,7 +2071,7 @@ contains
                                  tmp(1), plan_type_dtt)
 
       deallocate(a1)
-      deallocate(a2)
+      nullify (a2)
       if (.not. c_associated(plan)) call decomp_2d_abort(__FILE__, __LINE__, 19, "Plan creation failed")
 
    end subroutine r2r_1m_z_plan
@@ -3360,12 +3360,13 @@ contains
       ! Create 1D pointers starting at the ifirst / ofirst location
       call c_f_pointer(c_loc(inr), inr2, (/isz + ii - 1/))
       call c_f_pointer(c_loc(outr), outr2, (/osz + oi - 1/))
+      outr2(oi:) = inr2(ii:)
 
       ! Perform DFT
 #ifdef DOUBLE_PREC
-      call fftw_execute_r2r(plan, inr2(ii:), outr2(oi:))
+      call fftw_execute_r2r(plan, outr2(oi:), outr2(oi:))
 #else
-      call fftwf_execute_r2r(plan, inr2(ii:), outr2(oi:))
+      call fftwf_execute_r2r(plan, outr2(oi:), outr2(oi:))
 #endif
 
       ! Release pointers

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -61,6 +61,39 @@ module decomp_2d_fft
    logical, pointer, save :: skip_y_c2c => null()
    logical, pointer, save :: skip_z_c2c => null()
 
+   ! Flag to check if DTT is active
+   logical, pointer, save :: with_dtt => null()
+
+   ! Flag to check if a 1D DTT is periodic
+   logical, save :: dtt_x_dft, dtt_y_dft, dtt_z_dft
+
+   ! array with the DTT setup
+   integer, contiguous, pointer, save :: dtt(:) => null()
+
+   ! FFTW plans for DTT
+   !    1, 2, 3 : forward transform in X, Y and Z
+   !    4, 5, 6 : backward transform in X, Y and Z
+   type(C_PTR), contiguous, pointer, save :: dtt_plan(:) => null()
+
+   ! Decomposition objects for DTT
+   type(decomp_info), pointer, save :: dtt_decomp_xy => null(), &
+                                       dtt_decomp_yz => null(), &
+                                       dtt_decomp_sp => null()
+
+   ! Workspace for DTT
+   real(mytype), contiguous, pointer :: wk1ra(:, :, :) => null(), &
+                                        wk1ia(:, :, :) => null(), &
+                                        wk1rb(:, :, :) => null(), &
+                                        wk1ib(:, :, :) => null(), &
+                                        wk2ra(:, :, :) => null(), &
+                                        wk2ia(:, :, :) => null(), &
+                                        wk2rb(:, :, :) => null(), &
+                                        wk2ib(:, :, :) => null(), &
+                                        wk3ra(:, :, :) => null(), &
+                                        wk3ia(:, :, :) => null(), &
+                                        wk3rb(:, :, :) => null(), &
+                                        wk3ib(:, :, :) => null()
+
    ! Derived type with all the quantities needed to perform FFT
    type decomp_2d_fft_engine
       type(c_ptr), private :: plan(-1:2, 3), wk2_c2c_p, wk13_p
@@ -75,10 +108,35 @@ module decomp_2d_fft
       complex(mytype), contiguous, pointer, private :: wk13(:, :, :) => null()
       logical, private :: inplace, inplace_r2c, inplace_c2r
       logical, private :: skip_x_c2c, skip_y_c2c, skip_z_c2c
+      ! Below is specific to DTT
+      logical, public :: with_dtt
+      integer, allocatable, public, dimension(:) :: dtt
+      type(C_PTR), private :: dtt_plan(6)
+      type(decomp_info), pointer, public :: dtt_decomp_sp => null()
+      type(decomp_info), pointer, private :: dtt_decomp_xy => null(), &
+                                             dtt_decomp_yz => null()
+      type(decomp_info), private :: dtt_decomp_sp_target
+      type(c_ptr), private :: wk1ra_p, wk1ia_p, wk1rb_p, wk1ib_p, &
+                              wk2ra_p, wk2ia_p, wk2rb_p, wk2ib_p, &
+                              wk3ra_p, wk3ia_p, wk3rb_p, wk3ib_p
+      real(mytype), contiguous, pointer, private :: wk1ra(:, :, :) => null(), &
+                                                    wk1ia(:, :, :) => null(), &
+                                                    wk1rb(:, :, :) => null(), &
+                                                    wk1ib(:, :, :) => null(), &
+                                                    wk2ra(:, :, :) => null(), &
+                                                    wk2ia(:, :, :) => null(), &
+                                                    wk2rb(:, :, :) => null(), &
+                                                    wk2ib(:, :, :) => null(), &
+                                                    wk3ra(:, :, :) => null(), &
+                                                    wk3ia(:, :, :) => null(), &
+                                                    wk3rb(:, :, :) => null(), &
+                                                    wk3ib(:, :, :) => null()
    contains
       procedure, public :: init => decomp_2d_fft_engine_init
       procedure, public :: fin => decomp_2d_fft_engine_fin
       procedure, public :: use_it => decomp_2d_fft_engine_use_it
+      procedure, private :: dtt_init => decomp_2d_fft_engine_dtt_init
+      procedure, private :: dtt_fin => decomp_2d_fft_engine_dtt_fin
       generic, public :: fft => c2c, r2c, c2r
       procedure, private :: c2c => decomp_2d_fft_engine_fft_c2c
       procedure, private :: r2c => decomp_2d_fft_engine_fft_r2c
@@ -94,8 +152,10 @@ module decomp_2d_fft
    type(decomp_2d_fft_engine), allocatable, target, save :: fft_engines(:)
 
    public :: decomp_2d_fft_init, decomp_2d_fft_3d, &
+             decomp_2d_dtt_3d_x2r, decomp_2d_dtt_3d_r2x, &
              decomp_2d_fft_finalize, decomp_2d_fft_get_size, &
              decomp_2d_fft_get_ph, decomp_2d_fft_get_sp, &
+             decomp_2d_fft_get_dtt_sp, &
              decomp_2d_fft_get_ngrid, decomp_2d_fft_set_ngrid, &
              decomp_2d_fft_use_grid, decomp_2d_fft_engine, &
              decomp_2d_fft_get_engine, decomp_2d_fft_get_format, &
@@ -136,15 +196,17 @@ contains
 
    end subroutine fft_init_noarg
 
-   subroutine fft_init_arg(pencil, opt_skip_XYZ_c2c)     ! allow to handle Z-pencil input
+   subroutine fft_init_arg(pencil, opt_skip_XYZ_c2c, opt_DTT)     ! allow to handle Z-pencil input
 
       implicit none
 
       integer, intent(IN) :: pencil
       logical, dimension(3), intent(in), optional :: opt_skip_XYZ_c2c
+      integer, dimension(:), intent(in), optional :: opt_DTT
 
       call fft_init_one_grid(pencil, nx_global, ny_global, nz_global, &
-                             opt_skip_XYZ_c2c=opt_skip_XYZ_c2c)
+                             opt_skip_XYZ_c2c=opt_skip_XYZ_c2c, &
+                             opt_DTT=opt_DTT)
 
    end subroutine fft_init_arg
 
@@ -153,13 +215,15 @@ contains
                                 opt_inplace, &
                                 opt_inplace_r2c, &
                                 opt_inplace_c2r, &
-                                opt_skip_XYZ_c2c)
+                                opt_skip_XYZ_c2c, &
+                                opt_DTT)
 
       implicit none
 
       integer, intent(IN) :: pencil, nx, ny, nz
       logical, intent(in), optional :: opt_inplace, opt_inplace_r2c, opt_inplace_c2r
       logical, dimension(3), intent(in), optional :: opt_skip_XYZ_c2c
+      integer, dimension(:), intent(in), optional :: opt_DTT
 
       ! Only one FFT engine will be used
       call decomp_2d_fft_set_ngrid(1)
@@ -169,7 +233,8 @@ contains
                               opt_inplace, &
                               opt_inplace_r2c, &
                               opt_inplace_c2r, &
-                              opt_skip_XYZ_c2c=opt_skip_XYZ_c2c)
+                              opt_skip_XYZ_c2c=opt_skip_XYZ_c2c, &
+                              opt_DTT=opt_DTT)
 
    end subroutine fft_init_one_grid
 
@@ -178,13 +243,15 @@ contains
                                       opt_inplace, &
                                       opt_inplace_r2c, &
                                       opt_inplace_c2r, &
-                                      opt_skip_XYZ_c2c)
+                                      opt_skip_XYZ_c2c, &
+                                      opt_DTT)
 
       implicit none
 
       integer, intent(in) :: pencil, nx, ny, nz, igrid
       logical, intent(in), optional :: opt_inplace, opt_inplace_r2c, opt_inplace_c2r
       logical, dimension(3), intent(in), optional :: opt_skip_XYZ_c2c
+      integer, dimension(:), intent(in), optional :: opt_DTT
 
       ! Safety check
       if (igrid < 1 .or. igrid > n_grid) then
@@ -196,7 +263,8 @@ contains
                                    opt_inplace, &
                                    opt_inplace_r2c, &
                                    opt_inplace_c2r, &
-                                   opt_skip_XYZ_c2c)
+                                   opt_skip_XYZ_c2c, &
+                                   opt_DTT=opt_DTT)
 
    end subroutine fft_init_multiple_grids
 
@@ -205,7 +273,8 @@ contains
                                         opt_inplace, &
                                         opt_inplace_r2c, &
                                         opt_inplace_c2r, &
-                                        opt_skip_XYZ_c2c)
+                                        opt_skip_XYZ_c2c, &
+                                        opt_DTT)
 
       implicit none
 
@@ -213,6 +282,7 @@ contains
       integer, intent(in) :: pencil, nx, ny, nz
       logical, intent(in), optional :: opt_inplace, opt_inplace_r2c, opt_inplace_c2r
       logical, dimension(3), intent(in), optional :: opt_skip_XYZ_c2c
+      integer, dimension(:), intent(in), optional :: opt_DTT
 
       integer(C_SIZE_T) :: sz
 
@@ -320,6 +390,14 @@ contains
          end if
       end if
 
+      ! Prepare the DTT components
+      if (present(opt_DTT)) then
+         engine%with_dtt = .true.
+         call engine%dtt_init(opt_DTT)
+      else
+         engine%with_dtt = .false.
+      end if
+
       ! Warning : replace the default engine
       call engine%use_it(opt_force=.true.)
 
@@ -335,6 +413,327 @@ contains
       if (decomp_profiler_fft) call decomp_profiler_end("fft_init")
 
    end subroutine decomp_2d_fft_engine_init
+
+   ! Initialise the DTT components of the provided engine
+   subroutine decomp_2d_fft_engine_dtt_init(engine, in_DTT)
+
+      implicit none
+
+      class(decomp_2d_fft_engine), intent(inout), target :: engine
+      integer, dimension(:), intent(in) :: in_DTT
+
+      integer(C_SIZE_T) :: sz
+
+      ! Safety check
+      if (minval(in_DTT) < 0) call decomp_2d_abort(__FILE__, __LINE__, minval(in_DTT), "Invalid argument")
+      if (maxval(in_DTT) > 8) call decomp_2d_abort(__FILE__, __LINE__, maxval(in_DTT), "Invalid argument")
+
+      ! Prepare engine%dtt
+      ! Mandatory
+      !    1:3 => type of forward transform
+      ! Optional, default values in dtt_assign_default
+      !    4:6 => ifirst, index where the transform starts in the input
+      !    7:9 => ndismiss, number of points skipped
+      !    10:12 => ofirst, index where the transform starts in the output
+      ! Values defined in dtt_invert
+      !    12:15 => type of backward transform
+      allocate (engine%dtt(15))
+      if (size(in_DTT) == 12) then
+         engine%dtt(1:12) = in_DTT
+      elseif (size(in_DTT) == 3) then
+         engine%dtt(1:3) = in_DTT(:)
+         call dtt_assign_default(engine%dtt)
+      else
+         call decomp_2d_abort(__FILE__, __LINE__, size(in_DTT), "Invalid argument")
+      end if
+      call dtt_invert(engine%dtt)
+      call dtt_for_fftw(engine%dtt(1:3))
+      call dtt_for_fftw(engine%dtt(13:15))
+
+      ! Prepare the decomp_info objects
+      if (engine%format == PHYSICAL_IN_X) then
+         if (engine%dtt(1) == FFTW_FORWARD) then
+            engine%dtt_decomp_xy => engine%sp
+            engine%dtt_decomp_yz => engine%sp
+            engine%dtt_decomp_sp => engine%sp
+         else if (engine%dtt(2) == FFTW_FORWARD) then
+            engine%dtt_decomp_xy => engine%ph
+            call decomp_info_init(engine%nx_fft, engine%ny_fft / 2 + 1, engine%nz_fft, engine%dtt_decomp_sp_target)
+            engine%dtt_decomp_yz => engine%dtt_decomp_sp_target
+            engine%dtt_decomp_sp => engine%dtt_decomp_sp_target
+         else if (engine%dtt(3) == FFTW_FORWARD) then
+            engine%dtt_decomp_xy => engine%ph
+            engine%dtt_decomp_yz => engine%ph
+            call decomp_info_init(engine%nx_fft, engine%ny_fft, engine%nz_fft / 2 + 1, engine%dtt_decomp_sp_target)
+            engine%dtt_decomp_sp => engine%dtt_decomp_sp_target
+         else
+            engine%dtt_decomp_xy => engine%ph
+            engine%dtt_decomp_yz => engine%ph
+            engine%dtt_decomp_sp => engine%ph
+         end if
+      else
+         if (engine%dtt(3) == FFTW_FORWARD) then
+            engine%dtt_decomp_yz => engine%sp
+            engine%dtt_decomp_xy => engine%sp
+            engine%dtt_decomp_sp => engine%sp
+         else if (engine%dtt(2) == FFTW_FORWARD) then
+            engine%dtt_decomp_yz => engine%ph
+            call decomp_info_init(engine%nx_fft, engine%ny_fft / 2 + 1, engine%nz_fft, engine%dtt_decomp_sp_target)
+            engine%dtt_decomp_xy => engine%dtt_decomp_sp_target
+            engine%dtt_decomp_sp => engine%dtt_decomp_sp_target
+         else if (engine%dtt(1) == FFTW_FORWARD) then
+            engine%dtt_decomp_yz => engine%ph
+            engine%dtt_decomp_xy => engine%ph
+            call decomp_info_init(engine%nx_fft / 2 + 1, engine%ny_fft, engine%nz_fft, engine%dtt_decomp_sp_target)
+            engine%dtt_decomp_sp => engine%dtt_decomp_sp_target
+         else
+            engine%dtt_decomp_yz => engine%ph
+            engine%dtt_decomp_xy => engine%ph
+            engine%dtt_decomp_sp => engine%ph
+         end if
+      end if
+
+      ! Working arrays in x
+      if (engine%format == PHYSICAL_IN_X) then
+         ! Allocate the memory
+         sz = product(engine%ph%xsz)
+         engine%wk1ra_p = fftw_alloc_real(sz)
+         engine%wk1ia_p = fftw_alloc_real(sz)
+         ! Associated the pointers
+         call c_f_pointer(engine%wk1ra_p, engine%wk1ra, engine%ph%xsz)
+         call c_f_pointer(engine%wk1ia_p, engine%wk1ia, engine%ph%xsz)
+      else
+         sz = product(engine%dtt_decomp_sp%xsz)
+         engine%wk1ra_p = fftw_alloc_real(sz)
+         engine%wk1ia_p = fftw_alloc_real(sz)
+         ! Associated the pointers
+         call c_f_pointer(engine%wk1ra_p, engine%wk1ra, engine%dtt_decomp_sp%xsz)
+         call c_f_pointer(engine%wk1ia_p, engine%wk1ia, engine%dtt_decomp_sp%xsz)
+      end if
+      sz = product(engine%dtt_decomp_xy%xsz)
+      ! Allocate the memory
+      engine%wk1rb_p = fftw_alloc_real(sz)
+      engine%wk1ib_p = fftw_alloc_real(sz)
+      call c_f_pointer(engine%wk1rb_p, engine%wk1rb, engine%dtt_decomp_xy%xsz)
+      call c_f_pointer(engine%wk1ib_p, engine%wk1ib, engine%dtt_decomp_xy%xsz)
+      ! Set to zero
+      engine%wk1ra = 0._mytype
+      engine%wk1ia = 0._mytype
+      engine%wk1rb = 0._mytype
+      engine%wk1ib = 0._mytype
+
+      ! Working arrays in y
+      ! Allocate the memory
+      sz = product(engine%dtt_decomp_xy%ysz)
+      engine%wk2ra_p = fftw_alloc_real(sz)
+      engine%wk2ia_p = fftw_alloc_real(sz)
+      sz = product(engine%dtt_decomp_yz%ysz)
+      engine%wk2rb_p = fftw_alloc_real(sz)
+      engine%wk2ib_p = fftw_alloc_real(sz)
+      ! Associated the pointers
+      call c_f_pointer(engine%wk2ra_p, engine%wk2ra, engine%dtt_decomp_xy%ysz)
+      call c_f_pointer(engine%wk2ia_p, engine%wk2ia, engine%dtt_decomp_xy%ysz)
+      call c_f_pointer(engine%wk2rb_p, engine%wk2rb, engine%dtt_decomp_yz%ysz)
+      call c_f_pointer(engine%wk2ib_p, engine%wk2ib, engine%dtt_decomp_yz%ysz)
+      ! Set to zero
+      engine%wk2ra = 0._mytype
+      engine%wk2ia = 0._mytype
+      engine%wk2rb = 0._mytype
+      engine%wk2ib = 0._mytype
+
+      ! Working arrays in z
+      ! Allocate the memory
+      sz = product(engine%dtt_decomp_yz%zsz)
+      engine%wk3ra_p = fftw_alloc_real(sz)
+      engine%wk3ia_p = fftw_alloc_real(sz)
+      ! Associated the pointers
+      call c_f_pointer(engine%wk3ra_p, engine%wk3ra, engine%dtt_decomp_yz%zsz)
+      call c_f_pointer(engine%wk3ia_p, engine%wk3ia, engine%dtt_decomp_yz%zsz)
+      if (engine%format == PHYSICAL_IN_X) then
+         ! Allocate the memory
+         sz = product(engine%dtt_decomp_sp%zsz)
+         engine%wk3rb_p = fftw_alloc_real(sz)
+         engine%wk3ib_p = fftw_alloc_real(sz)
+         ! Associated the pointers
+         call c_f_pointer(engine%wk3rb_p, engine%wk3rb, engine%dtt_decomp_sp%zsz)
+         call c_f_pointer(engine%wk3ib_p, engine%wk3ib, engine%dtt_decomp_sp%zsz)
+      else
+         ! Allocate the memory
+         sz = product(engine%ph%zsz)
+         engine%wk3rb_p = fftw_alloc_real(sz)
+         engine%wk3ib_p = fftw_alloc_real(sz)
+         ! Associated the pointers
+         call c_f_pointer(engine%wk3rb_p, engine%wk3rb, engine%ph%zsz)
+         call c_f_pointer(engine%wk3ib_p, engine%wk3ib, engine%ph%zsz)
+      end if
+      ! Set to zero
+      engine%wk3ra = 0._mytype
+      engine%wk3ia = 0._mytype
+      engine%wk3rb = 0._mytype
+      engine%wk3ib = 0._mytype
+
+      ! Prepare the fftw plans
+      if (engine%format == PHYSICAL_IN_X) then
+         ! in x
+         if (engine%dtt(1) == FFTW_FORWARD) then
+            call r2rr_1m_x_plan(engine%dtt_plan(1), engine%ph, engine%sp, engine%dtt(7))
+            call rr2r_1m_x_plan(engine%dtt_plan(4), engine%sp, engine%ph, engine%dtt(7))
+         else
+            call r2r_1m_x_plan(engine%dtt_plan(1), engine%ph, engine%dtt(1), engine%dtt(7))
+            call r2r_1m_x_plan(engine%dtt_plan(4), engine%ph, engine%dtt(13), engine%dtt(7))
+         end if
+         ! in y
+         if (engine%dtt(2) == FFTW_FORWARD) then
+            if (engine%dtt(1) == FFTW_FORWARD) then
+               call rr2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(8))
+               call rr2rr_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt(8)) ! Duplicated plan, this can be improved
+            else
+               call r2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt_decomp_yz, engine%dtt(8))
+               call rr2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_yz, engine%dtt_decomp_xy, engine%dtt(8))
+            end if
+         else
+            call r2r_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(2), engine%dtt(8))
+            call r2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt(14), engine%dtt(8))
+         end if
+         ! in z
+         if (engine%dtt(3) == FFTW_FORWARD) then
+            if (engine%dtt(1) == FFTW_FORWARD .or. engine%dtt(2) == FFTW_FORWARD) then
+               call rr2rr_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_sp, engine%dtt(9))
+               call rr2rr_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp, engine%dtt(9)) ! Duplicated plan, this can be improved
+            else
+               call r2rr_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_yz, engine%dtt_decomp_sp, engine%dtt(9))
+               call rr2r_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp, engine%dtt_decomp_yz, engine%dtt(9))
+            end if
+         else
+            call r2r_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_sp, engine%dtt(3), engine%dtt(9))
+            call r2r_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp, engine%dtt(15), engine%dtt(9))
+         end if
+      else
+         ! in z
+         if (engine%dtt(3) == FFTW_FORWARD) then
+            call r2rr_1m_z_plan(engine%dtt_plan(3), engine%ph, engine%sp, engine%dtt(9))
+            call rr2r_1m_z_plan(engine%dtt_plan(6), engine%sp, engine%ph, engine%dtt(9))
+         else
+            call r2r_1m_z_plan(engine%dtt_plan(3), engine%ph, engine%dtt(3), engine%dtt(9))
+            call r2r_1m_z_plan(engine%dtt_plan(6), engine%ph, engine%dtt(15), engine%dtt(9))
+         end if
+         ! in y
+         if (engine%dtt(2) == FFTW_FORWARD) then
+            if (engine%dtt(3) == FFTW_FORWARD) then
+               call rr2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(8))
+               call rr2rr_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt(8)) ! Duplicated plan, this can be improved
+            else
+               call r2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_yz, engine%dtt_decomp_xy, engine%dtt(8))
+               call rr2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt_decomp_yz, engine%dtt(8))
+            end if
+         else
+            call r2r_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(2), engine%dtt(8))
+            call r2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt(14), engine%dtt(8))
+         end if
+         ! in x
+         if (engine%dtt(1) == FFTW_FORWARD) then
+            if (engine%dtt(2) == FFTW_FORWARD .or. engine%dtt(3) == FFTW_FORWARD) then
+               call rr2rr_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_sp, engine%dtt(7))
+               call rr2rr_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt(7)) ! Duplicated plan, this can be improved
+            else
+               call r2rr_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_xy, engine%dtt_decomp_sp, engine%dtt(7))
+               call rr2r_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt_decomp_xy, engine%dtt(7))
+            end if
+         else
+            call r2r_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_sp, engine%dtt(1), engine%dtt(7))
+            call r2r_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt(13), engine%dtt(7))
+         end if
+      end if
+
+   end subroutine decomp_2d_fft_engine_dtt_init
+
+   ! Set default values in the DTT config
+   subroutine dtt_assign_default(dtt)
+
+      implicit none
+
+      integer, intent(inout) :: dtt(15)
+
+      integer :: k
+
+      ! Generic values
+      ! ifirst = 1, use the array from the beginning
+      dtt(4:6) = 1
+      ! ndismiss = 1, skip one point
+      dtt(7:9) = 1
+
+      ! Specific cases
+      do k = 1, 3
+         if (dtt(k) == 0) dtt(k + 6) = 0 ! Periodic, ndismiss = 0
+         if (dtt(k) == 1) dtt(k + 6) = 0 ! DCT1, ndismiss = 0
+         if (dtt(k) == 5) dtt(k + 3) = 2 ! DST1, ifirst = 2
+         if (dtt(k) == 5) dtt(k + 6) = 2 ! DST1, ndismiss = 2
+         if (dtt(k) == 7) dtt(k + 3) = 2 ! DST3, ifirst = 2
+      end do
+
+      ! ofirst = ifirst
+      dtt(10:12) = dtt(4:6)
+
+   end subroutine dtt_assign_default
+
+   ! Set the backward transforms in the DTT config
+   subroutine dtt_invert(dtt)
+
+      implicit none
+
+      integer, intent(inout) :: dtt(15)
+
+      integer :: k
+
+      ! Default : inv(DTT) = DTT
+      dtt(13:15) = dtt(1:3)
+
+      ! Except for DCT2, DCT3, DST2, DST3
+      do k = 1, 3
+         if (dtt(k) == 0) dtt(12 + k) = 9
+         if (dtt(k) == 2) dtt(12 + k) = 3 ! inv(DCT2) = DCT3
+         if (dtt(k) == 3) dtt(12 + k) = 2 ! inv(DCT3) = DCT2
+         if (dtt(k) == 6) dtt(12 + k) = 7 ! inv(DST2) = DST3
+         if (dtt(k) == 7) dtt(12 + k) = 6 ! inv(DST3) = DST2
+      end do
+
+   end subroutine dtt_invert
+
+   ! Adapt the DTT type to FFTW
+   subroutine dtt_for_fftw(dtt)
+
+      implicit none
+
+      integer, intent(inout) :: dtt(:)
+
+      integer :: k
+
+      do k = 1, size(dtt)
+         select case (dtt(k))
+         case (0)
+            dtt(k) = FFTW_FORWARD
+         case (1)
+            dtt(k) = FFTW_REDFT00
+         case (2)
+            dtt(k) = FFTW_REDFT10
+         case (3)
+            dtt(k) = FFTW_REDFT01
+         case (4)
+            dtt(k) = FFTW_REDFT11
+         case (5)
+            dtt(k) = FFTW_RODFT00
+         case (6)
+            dtt(k) = FFTW_RODFT10
+         case (7)
+            dtt(k) = FFTW_RODFT01
+         case (8)
+            dtt(k) = FFTW_RODFT11
+         case (9)
+            dtt(k) = FFTW_BACKWARD
+         end select
+      end do
+
+   end subroutine dtt_for_fftw
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Final clean up
@@ -371,6 +770,26 @@ contains
       nullify (skip_x_c2c)
       nullify (skip_y_c2c)
       nullify (skip_z_c2c)
+      nullify (with_dtt)
+      if (associated(dtt_decomp_xy)) then
+         nullify (dtt)
+         nullify (dtt_plan)
+         nullify (dtt_decomp_xy)
+         nullify (dtt_decomp_yz)
+         nullify (dtt_decomp_sp)
+         nullify (wk1ra)
+         nullify (wk1ia)
+         nullify (wk1rb)
+         nullify (wk1ib)
+         nullify (wk2ra)
+         nullify (wk2ia)
+         nullify (wk2rb)
+         nullify (wk2ib)
+         nullify (wk3ra)
+         nullify (wk3ia)
+         nullify (wk3rb)
+         nullify (wk3ib)
+      end if
 
       ! Clean the FFTW library
       call fftw_cleanup()
@@ -405,11 +824,74 @@ contains
 
       call finalize_fft_engine(engine%plan)
 
+      if (engine%with_dtt) call engine%dtt_fin()
+
       engine%initialised = .false.
 
       if (decomp_profiler_fft) call decomp_profiler_end("fft_fin")
 
    end subroutine decomp_2d_fft_engine_fin
+
+   ! Clean the DTT components of the provided engine
+   subroutine decomp_2d_fft_engine_dtt_fin(engine)
+
+      implicit none
+
+      class(decomp_2d_fft_engine), intent(inout) :: engine
+
+      integer :: i
+
+      ! Restore the dtt flag
+      engine%with_dtt = .false.
+
+      ! Deallocate the DTT config
+      deallocate (engine%dtt)
+
+      ! Clean the decomp_info objects
+      nullify (engine%dtt_decomp_sp)
+      nullify (engine%dtt_decomp_xy)
+      nullify (engine%dtt_decomp_yz)
+      if (allocated(engine%dtt_decomp_sp_target%x1dist)) &
+         call decomp_info_finalize(engine%dtt_decomp_sp_target)
+
+      ! Release the memory
+      call fftw_free(engine%wk1ra_p)
+      call fftw_free(engine%wk1ia_p)
+      call fftw_free(engine%wk1rb_p)
+      call fftw_free(engine%wk1ib_p)
+      call fftw_free(engine%wk2ra_p)
+      call fftw_free(engine%wk2ia_p)
+      call fftw_free(engine%wk2rb_p)
+      call fftw_free(engine%wk2ib_p)
+      call fftw_free(engine%wk3ra_p)
+      call fftw_free(engine%wk3ia_p)
+      call fftw_free(engine%wk3rb_p)
+      call fftw_free(engine%wk3ib_p)
+
+      ! Set pointers to null
+      nullify (engine%wk1ra)
+      nullify (engine%wk1ia)
+      nullify (engine%wk1rb)
+      nullify (engine%wk1ib)
+      nullify (engine%wk2ra)
+      nullify (engine%wk2ia)
+      nullify (engine%wk2rb)
+      nullify (engine%wk2ib)
+      nullify (engine%wk3ra)
+      nullify (engine%wk3ia)
+      nullify (engine%wk3rb)
+      nullify (engine%wk3ib)
+
+      ! Clean the fftw plans
+      do i = 1, 6
+#ifdef DOUBLE_PREC
+         call fftw_destroy_plan(engine%dtt_plan(i))
+#else
+         call fftwf_destroy_plan(engine%dtt_plan(i))
+#endif
+      end do
+
+   end subroutine decomp_2d_fft_engine_dtt_fin
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Return the size, starting/ending index of the distributed array
@@ -469,6 +951,24 @@ contains
       decomp_2d_fft_get_sp => sp
 
    end function decomp_2d_fft_get_sp
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! Return a pointer to the decomp_info object sp used in DTT
+   !
+   ! The caller should not apply decomp_info_finalize on the pointer
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   function decomp_2d_fft_get_dtt_sp()
+
+      implicit none
+
+      type(decomp_info), pointer :: decomp_2d_fft_get_dtt_sp
+
+      if (.not. associated(dtt_decomp_sp)) then
+         call decomp_2d_abort(__FILE__, __LINE__, -1, 'No DTT available')
+      end if
+      decomp_2d_fft_get_dtt_sp => dtt_decomp_sp
+
+   end function decomp_2d_fft_get_dtt_sp
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Return the number of FFT grids
@@ -585,6 +1085,51 @@ contains
       skip_x_c2c => engine%skip_x_c2c
       skip_y_c2c => engine%skip_y_c2c
       skip_z_c2c => engine%skip_z_c2c
+      with_dtt => engine%with_dtt
+      dtt_x_dft = .false.
+      dtt_y_dft = .false.
+      dtt_z_dft = .false.
+
+      if (with_dtt) then
+         if (engine%dtt(1) == FFTW_FORWARD) dtt_x_dft = .true.
+         if (engine%dtt(2) == FFTW_FORWARD) dtt_y_dft = .true.
+         if (engine%dtt(3) == FFTW_FORWARD) dtt_z_dft = .true.
+         dtt => engine%dtt
+         dtt_plan => engine%dtt_plan
+         dtt_decomp_xy => engine%dtt_decomp_xy
+         dtt_decomp_yz => engine%dtt_decomp_yz
+         dtt_decomp_sp => engine%dtt_decomp_sp
+         wk1ra => engine%wk1ra
+         wk1ia => engine%wk1ia
+         wk1rb => engine%wk1rb
+         wk1ib => engine%wk1ib
+         wk2ra => engine%wk2ra
+         wk2ia => engine%wk2ia
+         wk2rb => engine%wk2rb
+         wk2ib => engine%wk2ib
+         wk3ra => engine%wk3ra
+         wk3ia => engine%wk3ia
+         wk3rb => engine%wk3rb
+         wk3ib => engine%wk3ib
+      else if (associated(dtt_decomp_xy)) then
+         nullify (dtt)
+         nullify (dtt_plan)
+         nullify (dtt_decomp_xy)
+         nullify (dtt_decomp_yz)
+         nullify (dtt_decomp_sp)
+         nullify (wk1ra)
+         nullify (wk1ia)
+         nullify (wk1rb)
+         nullify (wk1ib)
+         nullify (wk2ra)
+         nullify (wk2ia)
+         nullify (wk2rb)
+         nullify (wk2ib)
+         nullify (wk3ra)
+         nullify (wk3ia)
+         nullify (wk3rb)
+         nullify (wk3ib)
+      end if
 
    end subroutine decomp_2d_fft_engine_use_it
 
@@ -971,6 +1516,639 @@ contains
 
    end subroutine c2r_1m_z_plan
 
+   ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
+   subroutine rr2rr_1m_x_plan(plan, decomp, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a4(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a4(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p, a4_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = product(decomp%xsz) - ndismiss
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      a3_p = fftw_alloc_real(sz)
+      a4_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%xsz)
+      call c_f_pointer(a2_p, a2, decomp%xsz)
+      call c_f_pointer(a3_p, a3, decomp%xsz)
+      call c_f_pointer(a4_p, a4, decomp%xsz)
+
+      dims(1)%n = decomp%xsz(1) - ndismiss
+      dims(1)%is = 1
+      dims(1)%os = 1
+      howmany(1)%n = decomp%xsz(2) * decomp%xsz(3)
+      howmany(1)%is = decomp%xsz(1)
+      howmany(1)%os = decomp%xsz(1)
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      call fftw_free(a4_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+      nullify (a4)
+
+   end subroutine rr2rr_1m_x_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
+   subroutine rr2rr_1m_y_plan(plan, decomp, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a4(:, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :)
+      real(C_FLOAT), contiguous, pointer :: a4(:, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p, a4_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = decomp%ysz(1) * (decomp%ysz(2) - ndismiss)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      a3_p = fftw_alloc_real(sz)
+      a4_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a2_p, a2, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a3_p, a3, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a4_p, a4, (/decomp%ysz(1), decomp%ysz(2)/))
+
+      dims(1)%n = decomp%ysz(2) - ndismiss
+      dims(1)%is = decomp%ysz(1)
+      dims(1)%os = decomp%ysz(1)
+      howmany(1)%n = decomp%ysz(1)
+      howmany(1)%is = 1
+      howmany(1)%os = 1
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      call fftw_free(a4_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+      nullify (a4)
+
+   end subroutine rr2rr_1m_y_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
+   subroutine rr2rr_1m_z_plan(plan, decomp, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a4(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a4(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p, a4_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = product(decomp%zsz)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      a3_p = fftw_alloc_real(sz)
+      a4_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%zsz)
+      call c_f_pointer(a2_p, a2, decomp%zsz)
+      call c_f_pointer(a3_p, a3, decomp%zsz)
+      call c_f_pointer(a4_p, a4, decomp%zsz)
+
+      dims(1)%n = decomp%zsz(3) - ndismiss
+      dims(1)%is = decomp%zsz(1) * decomp%zsz(2)
+      dims(1)%os = decomp%zsz(1) * decomp%zsz(2)
+      howmany(1)%n = decomp%zsz(1) * decomp%zsz(2)
+      howmany(1)%is = 1
+      howmany(1)%os = 1
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      call fftw_free(a4_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+      nullify (a4)
+
+   end subroutine rr2rr_1m_z_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
+   subroutine rr2r_1m_x_plan(plan, decomp, decomp2, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = product(decomp%xsz)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      sz = product(decomp2%xsz)
+      a3_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%xsz)
+      call c_f_pointer(a2_p, a2, decomp%xsz)
+      call c_f_pointer(a3_p, a3, decomp2%xsz)
+
+      dims(1)%n = decomp2%xsz(1) - ndismiss
+      dims(1)%is = 1
+      dims(1)%os = 1
+      howmany(1)%n = decomp%xsz(2) * decomp%xsz(3)
+      howmany(1)%is = decomp%xsz(1)
+      howmany(1)%os = decomp2%xsz(1)
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+
+   end subroutine rr2r_1m_x_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
+   subroutine rr2r_1m_y_plan(plan, decomp, decomp2, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = decomp%ysz(1) * decomp%ysz(2)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      sz = decomp2%ysz(1) * decomp2%ysz(2)
+      a3_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a2_p, a2, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a3_p, a3, (/decomp2%ysz(1), decomp2%ysz(2)/))
+
+      dims(1)%n = decomp2%ysz(2) - ndismiss
+      dims(1)%is = decomp%ysz(1)
+      dims(1)%os = decomp2%ysz(1)
+      howmany(1)%n = decomp%ysz(1)
+      howmany(1)%is = 1
+      howmany(1)%os = 1
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+
+   end subroutine rr2r_1m_y_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
+   subroutine rr2r_1m_z_plan(plan, decomp, decomp2, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = product(decomp%zsz)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      sz = product(decomp2%zsz)
+      a3_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%zsz)
+      call c_f_pointer(a2_p, a2, decomp%zsz)
+      call c_f_pointer(a3_p, a3, decomp2%zsz)
+
+      dims(1)%n = decomp2%zsz(3) - ndismiss
+      dims(1)%is = decomp%zsz(1) * decomp%zsz(2)
+      dims(1)%os = decomp2%zsz(1) * decomp2%zsz(2)
+      howmany(1)%n = decomp%zsz(1) * decomp%zsz(2)
+      howmany(1)%is = 1
+      howmany(1)%os = 1
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+
+   end subroutine rr2r_1m_z_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
+   subroutine r2rr_1m_x_plan(plan, decomp, decomp2, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = product(decomp%xsz)
+      a1_p = fftw_alloc_real(sz)
+      sz = product(decomp2%xsz)
+      a2_p = fftw_alloc_real(sz)
+      a3_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%xsz)
+      call c_f_pointer(a2_p, a2, decomp2%xsz)
+      call c_f_pointer(a3_p, a3, decomp2%xsz)
+
+      dims(1)%n = decomp%xsz(1) - ndismiss
+      dims(1)%is = 1
+      dims(1)%os = 1
+      howmany(1)%n = decomp%xsz(2) * decomp%xsz(3)
+      howmany(1)%is = decomp%xsz(1)
+      howmany(1)%os = decomp2%xsz(1)
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+
+   end subroutine r2rr_1m_x_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
+   subroutine r2rr_1m_y_plan(plan, decomp, decomp2, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = decomp%ysz(1) * decomp%ysz(2)
+      a1_p = fftw_alloc_real(sz)
+      sz = decomp2%ysz(1) * decomp2%ysz(2)
+      a2_p = fftw_alloc_real(sz)
+      a3_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a2_p, a2, (/decomp2%ysz(1), decomp2%ysz(2)/))
+      call c_f_pointer(a3_p, a3, (/decomp2%ysz(1), decomp2%ysz(2)/))
+
+      dims(1)%n = decomp%ysz(2) - ndismiss
+      dims(1)%is = decomp%ysz(1)
+      dims(1)%os = decomp2%ysz(1)
+      howmany(1)%n = decomp%ysz(1)
+      howmany(1)%is = 1
+      howmany(1)%os = 1
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+
+   end subroutine r2rr_1m_y_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
+   subroutine r2rr_1m_z_plan(plan, decomp, decomp2, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a3(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a3(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p, a3_p
+      integer(C_SIZE_T) :: sz
+      type(fftw_iodim) :: dims(1), howmany(1)
+
+      sz = product(decomp%zsz)
+      a1_p = fftw_alloc_real(sz)
+      sz = product(decomp2%zsz)
+      a2_p = fftw_alloc_real(sz)
+      a3_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%zsz)
+      call c_f_pointer(a2_p, a2, decomp2%zsz)
+      call c_f_pointer(a3_p, a3, decomp2%zsz)
+
+      dims(1)%n = decomp%zsz(3) - ndismiss
+      dims(1)%is = decomp%zsz(1) * decomp%zsz(2)
+      dims(1)%os = decomp2%zsz(1) * decomp2%zsz(2)
+      howmany(1)%n = decomp%zsz(1) * decomp%zsz(2)
+      howmany(1)%is = 1
+      howmany(1)%os = 1
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#else
+      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+#endif
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      call fftw_free(a3_p)
+      nullify (a1)
+      nullify (a2)
+      nullify (a3)
+
+   end subroutine r2rr_1m_z_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
+   subroutine r2r_1m_x_plan(plan, decomp, dtt, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp
+      integer, intent(in) :: dtt
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p
+      integer(C_SIZE_T) :: sz
+      integer(C_INT) :: ntmp(1)
+      integer(C_FFTW_R2R_KIND) :: tmp(1)
+
+      sz = product(decomp%xsz)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%xsz)
+      call c_f_pointer(a2_p, a2, decomp%xsz)
+
+      ntmp(1) = decomp%xsz(1) - ndismiss
+      tmp(1) = dtt
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), &
+#else
+      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), & !&
+#endif
+                                 a1, decomp%xsz(1), 1, decomp%xsz(1), &
+                                 a2, decomp%xsz(1), 1, decomp%xsz(1), &
+                                 tmp(1), plan_type)
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      nullify (a1)
+      nullify (a2)
+
+   end subroutine r2r_1m_x_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
+   subroutine r2r_1m_y_plan(plan, decomp, dtt, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp
+      integer, intent(in) :: dtt
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p
+      integer(C_SIZE_T) :: sz
+      integer(C_INT) :: ntmp(1)
+      integer(C_FFTW_R2R_KIND) :: tmp(1)
+
+      sz = decomp%ysz(1) * decomp%ysz(2)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, (/decomp%ysz(1), decomp%ysz(2)/))
+      call c_f_pointer(a2_p, a2, (/decomp%ysz(1), decomp%ysz(2)/))
+
+      ntmp(1) = decomp%ysz(2) - ndismiss
+      tmp(1) = dtt
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_many_r2r(1, ntmp(1), decomp%ysz(1), &
+#else
+      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%ysz(1), & !&
+#endif
+                                 a1, decomp%ysz(2), decomp%ysz(1), 1, &
+                                 a2, decomp%ysz(2), decomp%ysz(1), 1, &
+                                 tmp(1), plan_type)
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      nullify (a1)
+      nullify (a2)
+
+   end subroutine r2r_1m_y_plan
+
+   ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
+   subroutine r2r_1m_z_plan(plan, decomp, dtt, ndismiss)
+
+      implicit none
+
+      type(C_PTR), intent(out) :: plan
+      TYPE(DECOMP_INFO), intent(in) :: decomp
+      integer, intent(in) :: dtt
+      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
+
+      ! Local variables
+#ifdef DOUBLE_PREC
+      real(C_DOUBLE), contiguous, pointer :: a1(:, :, :)
+      real(C_DOUBLE), contiguous, pointer :: a2(:, :, :)
+#else
+      real(C_FLOAT), contiguous, pointer :: a1(:, :, :)
+      real(C_FLOAT), contiguous, pointer :: a2(:, :, :)
+#endif
+      type(C_PTR) :: a1_p, a2_p
+      integer(C_SIZE_T) :: sz
+      integer(C_INT) :: ntmp(1)
+      integer(C_FFTW_R2R_KIND) :: tmp(1)
+
+      sz = product(decomp%zsz)
+      a1_p = fftw_alloc_real(sz)
+      a2_p = fftw_alloc_real(sz)
+      call c_f_pointer(a1_p, a1, decomp%zsz)
+      call c_f_pointer(a2_p, a2, decomp%zsz)
+
+      ntmp(1) = decomp%zsz(3) - ndismiss
+      tmp(1) = dtt
+#ifdef DOUBLE_PREC
+      plan = fftw_plan_many_r2r(1, ntmp(1), decomp%zsz(1) * decomp%zsz(2), &
+#else
+      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%zsz(1) * decomp%zsz(2), & !&
+#endif
+                                 a1, decomp%zsz(3), decomp%zsz(1) * decomp%zsz(2), 1, &
+                                 a2, decomp%zsz(3), decomp%zsz(1) * decomp%zsz(2), 1, &
+                                 tmp(1), plan_type)
+
+      call fftw_free(a1_p)
+      call fftw_free(a2_p)
+      nullify (a1)
+      nullify (a2)
+
+   end subroutine r2r_1m_z_plan
+
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !  This routine performs one-time initialisations for the FFT engine
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1186,6 +2364,354 @@ contains
       return
 
    end subroutine c2r_1m_z
+
+   ! rr2rr transform, x direction
+   subroutine rr2rr_1m_x(inr, ini, outr, outi, isign)
+
+      implicit none
+
+      ! Arguments
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
+      integer, intent(in) :: isign
+
+      ! Local variables
+      type(c_ptr) :: plan
+      integer :: ifirst, ofirst
+
+      ! Copy and exit if needed
+      if (skip_x_c2c) then
+         outr = inr
+         outi = ini
+         return
+      end if
+
+      ! Get the DTT config
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         plan = dtt_plan(1)
+         ifirst = dtt(4)
+         ofirst = dtt(10)
+      else
+         plan = dtt_plan(4)
+         ifirst = dtt(10)
+         ofirst = dtt(4)
+      end if
+
+      ! Perform the DFT
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         call wrapper_rr2rr(plan, &
+                            inr, ini, ifirst, 1, 1, size(inr) - ifirst + 1, &
+                            outr, outi, ofirst, 1, 1, size(outr) - ofirst + 1)
+      else
+         call wrapper_rr2rr(plan, &
+                            ini, inr, ifirst, 1, 1, size(inr) - ifirst + 1, &
+                            outi, outr, ofirst, 1, 1, size(outr) - ofirst + 1)
+      end if
+
+   end subroutine rr2rr_1m_x
+
+   ! rr2rr transform, y direction
+   subroutine rr2rr_1m_y(inr, ini, outr, outi, isign)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      integer, intent(in) :: isign
+
+      ! Local variables
+      integer :: k, ifirst, ofirst
+      type(c_ptr) :: plan
+
+      ! Copy and exit if needed
+      if (skip_y_c2c) then
+         outr = inr
+         outi = ini
+         return
+      end if
+
+      ! Get the DTT config
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         plan = dtt_plan(2)
+         ifirst = dtt(5)
+         ofirst = dtt(11)
+      else
+         plan = dtt_plan(5)
+         ifirst = dtt(11)
+         ofirst = dtt(5)
+      end if
+
+      ! Perform the DFT
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         do k = 1, size(inr, 3)
+            call wrapper_rr2rr(plan, &
+                               inr, ini, 1, ifirst, k, size(inr, 1) * (size(inr, 2) - ifirst + 1), &
+                               outr, outi, 1, ofirst, k, size(outr, 1) * (size(outr, 2) - ofirst + 1))
+         end do
+      else
+         do k = 1, size(inr, 3)
+            call wrapper_rr2rr(plan, &
+                               ini, inr, 1, ifirst, k, size(inr, 1) * (size(inr, 2) - ifirst + 1), &
+                               outi, outr, 1, ofirst, k, size(outr, 1) * (size(outr, 2) - ofirst + 1))
+         end do
+      end if
+
+   end subroutine rr2rr_1m_y
+
+   ! rr2rr transform, z direction
+   subroutine rr2rr_1m_z(inr, ini, outr, outi, isign)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      integer, intent(in) :: isign
+
+      ! Local variables
+      type(c_ptr) :: plan
+      integer :: ifirst, ofirst
+
+      ! Copy and exit if needed
+      if (skip_z_c2c) then
+         outr = inr
+         outi = ini
+         return
+      end if
+
+      ! Get the DTT config
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         plan = dtt_plan(3)
+         ifirst = dtt(6)
+         ofirst = dtt(12)
+      else
+         plan = dtt_plan(6)
+         ifirst = dtt(12)
+         ofirst = dtt(6)
+      end if
+
+      ! Perform the DFT
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         call wrapper_rr2rr(plan, &
+                            inr, ini, 1, 1, ifirst, size(inr, 1) * size(inr, 2) * (size(inr, 3) - ifirst + 1), &
+                            outr, outi, 1, 1, ofirst, size(outr, 1) * size(outr, 2) * (size(outr, 3) - ofirst + 1))
+      else
+         call wrapper_rr2rr(plan, &
+                            ini, inr, 1, 1, ifirst, size(inr, 1) * size(inr, 2) * (size(inr, 3) - ifirst + 1), &
+                            outi, outr, 1, 1, ofirst, size(outr, 1) * size(outr, 2) * (size(outr, 3) - ofirst + 1))
+      end if
+
+   end subroutine rr2rr_1m_z
+
+   ! r2r transform, x direction
+   subroutine r2r_1m_x(inr, outr, isign)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr
+      real(mytype), dimension(:, :, :), intent(out) :: outr
+      integer, intent(in) :: isign
+
+      ! Local variables
+      type(c_ptr) :: plan
+      integer :: ifirst, ofirst
+
+      ! Copy and exit if needed
+      if (skip_x_c2c) then
+         outr = inr
+         return
+      end if
+
+      ! Get the DTT config
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         plan = dtt_plan(1)
+         ifirst = dtt(4)
+         ofirst = dtt(10)
+      else
+         plan = dtt_plan(4)
+         ifirst = dtt(10)
+         ofirst = dtt(4)
+      end if
+
+      ! Perform the DFT
+      call wrapper_r2r(plan, &
+                       inr, ifirst, 1, 1, size(inr) - ifirst + 1, &
+                       outr, ofirst, 1, 1, size(outr) - ofirst + 1)
+
+   end subroutine r2r_1m_x
+
+   ! r2r transform, y direction
+   subroutine r2r_1m_y(inr, outr, isign)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr
+      real(mytype), dimension(:, :, :), intent(out) :: outr
+      integer, intent(in) :: isign
+
+      ! Local variables
+      type(c_ptr) :: plan
+      integer :: k, ifirst, ofirst
+
+      ! Copy and exit if needed
+      if (skip_y_c2c) then
+         outr = inr
+         return
+      end if
+
+      ! Get the DTT config
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         plan = dtt_plan(2)
+         ifirst = dtt(5)
+         ofirst = dtt(11)
+      else
+         plan = dtt_plan(5)
+         ifirst = dtt(11)
+         ofirst = dtt(5)
+      end if
+
+      ! Perform the DFT
+      do k = 1, size(inr, 3)
+         call wrapper_r2r(plan, &
+                          inr, 1, ifirst, k, size(inr, 1) * (size(inr, 2) - ifirst + 1), &
+                          outr, 1, ofirst, k, size(outr, 1) * (size(outr, 2) - ofirst + 1))
+      end do
+
+   end subroutine r2r_1m_y
+
+   ! r2r transform, z direction
+   subroutine r2r_1m_z(inr, outr, isign)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr
+      real(mytype), dimension(:, :, :), intent(out) :: outr
+      integer, intent(in) :: isign
+
+      ! Local variables
+      type(c_ptr) :: plan
+      integer :: ifirst, ofirst
+
+      ! Copy and exit if needed
+      if (skip_z_c2c) then
+         outr = inr
+         return
+      end if
+
+      ! Get the DTT config
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         plan = dtt_plan(3)
+         ifirst = dtt(6)
+         ofirst = dtt(12)
+      else
+         plan = dtt_plan(6)
+         ifirst = dtt(12)
+         ofirst = dtt(6)
+      end if
+
+      ! Perform the DFT
+      call wrapper_r2r(plan, &
+                       inr, 1, 1, ifirst, size(inr, 1) * size(inr, 2) * (size(inr, 3) - ifirst + 1), &
+                       outr, 1, 1, ofirst, size(outr, 1) * size(outr, 2) * (size(outr, 3) - ofirst + 1))
+
+   end subroutine r2r_1m_z
+
+   ! rr2r transform, x direction
+   subroutine rr2r_1m_x(inr, ini, outr)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), intent(out) :: outr
+
+      ! Perform the DFT
+      call wrapper_rr2r(dtt_plan(4), &
+                        inr, ini, dtt(10), 1, 1, size(inr) - dtt(10) + 1, &
+                        outr, dtt(4), 1, 1, size(outr) - dtt(4) + 1)
+
+   end subroutine rr2r_1m_x
+
+   ! rr2r transform, y direction
+   subroutine rr2r_1m_y(inr, ini, outr)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), intent(out) :: outr
+
+      integer :: k
+
+      ! Perform the DFT
+      do k = 1, size(inr, 3)
+         call wrapper_rr2r(dtt_plan(5), &
+                           inr, ini, 1, dtt(11), k, size(inr, 1) * (size(inr, 2) - dtt(11) + 1), &
+                           outr, 1, dtt(5), k, size(outr, 1) * (size(outr, 2) - dtt(5) + 1))
+      end do
+
+   end subroutine rr2r_1m_y
+
+   ! rr2r transform, z direction
+   subroutine rr2r_1m_z(inr, ini, outr)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), intent(out) :: outr
+
+      ! Perform the DFT
+      call wrapper_rr2r(dtt_plan(6), &
+                        inr, ini, 1, 1, dtt(12), size(inr, 1) * size(inr, 2) * (size(inr, 3) - dtt(12) + 1), &
+                        outr, 1, 1, dtt(6), size(outr, 1) * size(outr, 2) * (size(outr, 3) - dtt(6) + 1))
+
+   end subroutine rr2r_1m_z
+
+   ! r2rr transform, x direction
+   subroutine r2rr_1m_x(inr, outr, outi)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr
+      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+
+      ! Perform the DFT
+      call wrapper_r2rr(dtt_plan(1), &
+                        inr, dtt(4), 1, 1, size(inr) - dtt(4) + 1, &
+                        outr, outi, dtt(10), 1, 1, size(outr) - dtt(10) + 1)
+
+   end subroutine r2rr_1m_x
+
+   ! r2rr transform, y direction
+   subroutine r2rr_1m_y(inr, outr, outi)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr
+      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+
+      integer :: k
+
+      ! Perform the DFT
+      do k = 1, size(inr, 3)
+         call wrapper_r2rr(dtt_plan(2), &
+                           inr, 1, dtt(5), k, size(inr, 1) * (size(inr, 2) - dtt(5) + 1), &
+                           outr, outi, 1, dtt(11), k, size(outr, 1) * (size(outr, 2) - dtt(11) + 1))
+      end do
+
+   end subroutine r2rr_1m_y
+
+   ! r2rr transform, z direction
+   subroutine r2rr_1m_z(inr, outr, outi)
+
+      implicit none
+
+      real(mytype), dimension(:, :, :), intent(inout) :: inr
+      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+
+      ! Perform the DFT
+      call wrapper_r2rr(dtt_plan(3), &
+                        inr, 1, 1, dtt(6), size(inr, 1) * size(inr, 2) * (size(inr, 3) - dtt(6) + 1), &
+                        outr, outi, 1, 1, dtt(12), size(outr, 1) * size(outr, 2) * (size(outr, 3) - dtt(12) + 1))
+
+   end subroutine r2rr_1m_z
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! 3D FFT - complex to complex
@@ -1500,6 +3026,338 @@ contains
    end subroutine fft_3d_c2r
 
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! Forward 3D DTT - real to real/complex
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   subroutine decomp_2d_dtt_3d_r2x(in, out_real, out_cplx)
+
+      implicit none
+
+      ! Arguments
+      real(mytype), dimension(:, :, :), intent(inout) :: in
+      real(mytype), dimension(:, :, :), intent(out), optional :: out_real
+      complex(mytype), dimension(:, :, :), intent(out), optional :: out_cplx
+
+      ! Local variables
+      logical :: cplx
+      integer :: i, j, k
+
+      if (decomp_profiler_fft) call decomp_profiler_start("decomp_2d_dtt_3d_r2x")
+
+      ! Safety check
+      if (.not. (present(out_real) .or. present(out_cplx))) then
+         call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+      end if
+
+      ! Init
+      cplx = .false.
+
+      ! Perform the 3D DTT
+      if (format == PHYSICAL_IN_X) then
+
+         ! DFT / DTT in x
+         if (dtt_x_dft) then
+            call r2rr_1m_x(in, wk1rb, wk1ib)
+            cplx = .true.
+         else
+            call r2r_1m_x(in, wk1rb, DECOMP_2D_FFT_FORWARD)
+         end if
+
+         ! Transpose x => y
+         call transpose_x_to_y(wk1rb, wk2ra, dtt_decomp_xy)
+         if (cplx) then
+            call transpose_x_to_y(wk1ib, wk2ia, dtt_decomp_xy)
+         end if
+
+         ! DFT / DTT in y
+         if (dtt_y_dft) then
+            if (cplx) then
+               call rr2rr_1m_y(wk2ra, wk2ia, wk2rb, wk2ib, DECOMP_2D_FFT_FORWARD)
+            else
+               call r2rr_1m_y(wk2ra, wk2rb, wk2ib)
+               cplx = .true.
+            end if
+         else
+            call r2r_1m_y(wk2ra, wk2rb, DECOMP_2D_FFT_FORWARD)
+            if (cplx) then
+               call r2r_1m_y(wk2ia, wk2ib, DECOMP_2D_FFT_FORWARD)
+            end if
+         end if
+
+         ! Transpose y => z
+         call transpose_y_to_z(wk2rb, wk3ra, dtt_decomp_yz)
+         if (cplx) then
+            call transpose_y_to_z(wk2ib, wk3ia, dtt_decomp_yz)
+         end if
+
+         ! DFT / DTT in z
+         if (dtt_z_dft) then
+            if (cplx) then
+               call rr2rr_1m_z(wk3ra, wk3ia, wk3rb, wk3ib, DECOMP_2D_FFT_FORWARD)
+            else
+               call r2rr_1m_z(wk3ra, wk3rb, wk3ib)
+               cplx = .true.
+            end if
+         else
+            if (cplx) then
+               call r2r_1m_z(wk3ra, wk3rb, DECOMP_2D_FFT_FORWARD)
+               call r2r_1m_z(wk3ia, wk3ib, DECOMP_2D_FFT_FORWARD)
+            else
+               if (.not. present(out_real)) call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+               call r2r_1m_z(wk3ra, out_real, DECOMP_2D_FFT_FORWARD)
+            end if
+         end if
+
+      else
+
+         ! DFT / DTT in z
+         if (dtt_z_dft) then
+            call r2rr_1m_z(in, wk3ra, wk3ia)
+            cplx = .true.
+         else
+            call r2r_1m_z(in, wk3ra, DECOMP_2D_FFT_FORWARD)
+         end if
+
+         ! Transpose z => y
+         call transpose_z_to_y(wk3ra, wk2rb, dtt_decomp_yz)
+         if (cplx) then
+            call transpose_z_to_y(wk3ia, wk2ib, dtt_decomp_yz)
+         end if
+
+         ! DFT / DTT in y
+         if (dtt_y_dft) then
+            if (cplx) then
+               call rr2rr_1m_y(wk2rb, wk2ib, wk2ra, wk2ia, DECOMP_2D_FFT_FORWARD)
+            else
+               call r2rr_1m_y(wk2rb, wk2ra, wk2ia)
+               cplx = .true.
+            end if
+         else
+            call r2r_1m_y(wk2rb, wk2ra, DECOMP_2D_FFT_FORWARD)
+            if (cplx) then
+               call r2r_1m_y(wk2ib, wk2ia, DECOMP_2D_FFT_FORWARD)
+            end if
+         end if
+
+         ! Transpose y => x
+         call transpose_y_to_x(wk2ra, wk1rb, dtt_decomp_xy)
+         if (cplx) then
+            call transpose_y_to_x(wk2ia, wk1ib, dtt_decomp_xy)
+         end if
+
+         ! DFT / DTT in x
+         if (dtt_x_dft) then
+            if (cplx) then
+               call rr2rr_1m_x(wk1rb, wk1ib, wk1ra, wk1ia, DECOMP_2D_FFT_FORWARD)
+            else
+               call r2rr_1m_x(wk1rb, wk1ra, wk1ia)
+               cplx = .true.
+            end if
+         else
+            if (cplx) then
+               call r2r_1m_x(wk1rb, wk1ra, DECOMP_2D_FFT_FORWARD)
+               call r2r_1m_x(wk1ib, wk1ia, DECOMP_2D_FFT_FORWARD)
+            else
+               if (.not. present(out_real)) call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+               call r2r_1m_x(wk1rb, out_real, DECOMP_2D_FFT_FORWARD)
+            end if
+         end if
+
+      end if
+
+      ! Safety check
+      if (cplx .and. (.not. present(out_cplx))) then
+         call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+      end if
+
+      ! Recombine the real and imag parts if needed
+      if (cplx .and. format == PHYSICAL_IN_X) then
+         do k = 1, dtt_decomp_sp%zsz(3)
+            do j = 1, dtt_decomp_sp%zsz(2)
+               do i = 1, dtt_decomp_sp%zsz(1)
+                  out_cplx(i, j, k) = cmplx(wk3rb(i, j, k), wk3ib(i, j, k), kind=mytype)
+               end do
+            end do
+         end do
+      else if (cplx) then
+         do k = 1, dtt_decomp_sp%xsz(3)
+            do j = 1, dtt_decomp_sp%xsz(2)
+               do i = 1, dtt_decomp_sp%xsz(1)
+                  out_cplx(i, j, k) = cmplx(wk1ra(i, j, k), wk1ia(i, j, k), kind=mytype)
+               end do
+            end do
+         end do
+      end if
+
+      if (decomp_profiler_fft) call decomp_profiler_end("decomp_2d_dtt_3d_r2x")
+
+   end subroutine decomp_2d_dtt_3d_r2x
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! Backward 3D DTT - real/complex to real
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   subroutine decomp_2d_dtt_3d_x2r(in_real, in_cplx, out)
+
+      implicit none
+
+      ! Arguments
+      real(mytype), dimension(:, :, :), intent(inout), optional :: in_real
+      complex(mytype), dimension(:, :, :), intent(inout), optional :: in_cplx
+      real(mytype), dimension(:, :, :), intent(out), optional :: out
+
+      ! Local variables
+      logical :: cplx
+      integer :: i, j, k
+
+      if (decomp_profiler_fft) call decomp_profiler_start("decomp_2d_dtt_3d_x2r")
+
+      ! Init
+      if (dtt_x_dft .or. dtt_y_dft .or. dtt_z_dft) then
+         cplx = .true.
+      else
+         cplx = .false.
+      end if
+
+      ! Safety check
+      if (cplx) then
+         if (.not. present(in_cplx)) call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+      else
+         if (.not. present(in_real)) call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+      end if
+      if (.not. present(out)) call decomp_2d_abort(__FILE__, __LINE__, 1, "Invalid arguments")
+
+      ! Split real and imag parts if needed
+      if (cplx) then
+         if (format == PHYSICAL_IN_X) then
+            do k = 1, dtt_decomp_sp%zsz(3)
+               do j = 1, dtt_decomp_sp%zsz(2)
+                  do i = 1, dtt_decomp_sp%zsz(1)
+                     wk3rb(i, j, k) = real(in_cplx(i, j, k), kind=mytype)
+                     wk3ib(i, j, k) = aimag(in_cplx(i, j, k))
+                  end do
+               end do
+            end do
+         else
+            do k = 1, dtt_decomp_sp%xsz(3)
+               do j = 1, dtt_decomp_sp%xsz(2)
+                  do i = 1, dtt_decomp_sp%xsz(1)
+                     wk1ra(i, j, k) = real(in_cplx(i, j, k), kind=mytype)
+                     wk1ia(i, j, k) = aimag(in_cplx(i, j, k))
+                  end do
+               end do
+            end do
+         end if
+      end if
+
+      ! Perform the 3D DTT
+      if (format == PHYSICAL_IN_Z) then
+
+         ! DFT / DTT in x
+         if (dtt_x_dft) then
+            if (dtt_y_dft .or. dtt_z_dft) then
+               call rr2rr_1m_x(wk1ra, wk1ia, wk1rb, wk1ib, DECOMP_2D_FFT_BACKWARD)
+            else
+               call rr2r_1m_x(wk1ra, wk1ia, wk1rb)
+               cplx = .false.
+            end if
+         else
+            if (cplx) then
+               call r2r_1m_x(wk1ra, wk1rb, DECOMP_2D_FFT_BACKWARD)
+               call r2r_1m_x(wk1ia, wk1ib, DECOMP_2D_FFT_BACKWARD)
+            else
+               call r2r_1m_x(in_real, wk1rb, DECOMP_2D_FFT_BACKWARD)
+            end if
+         end if
+
+         ! Transpose x => y
+         call transpose_x_to_y(wk1rb, wk2ra, dtt_decomp_xy)
+         if (cplx) then
+            call transpose_x_to_y(wk1ib, wk2ia, dtt_decomp_xy)
+         end if
+
+         ! DFT / DTT in y
+         if (dtt_y_dft) then
+            if (dtt_z_dft) then
+               call rr2rr_1m_y(wk2ra, wk2ia, wk2rb, wk2ib, DECOMP_2D_FFT_BACKWARD)
+            else
+               call rr2r_1m_y(wk2ra, wk2ia, wk2rb)
+               cplx = .false.
+            end if
+         else
+            call r2r_1m_y(wk2ra, wk2rb, DECOMP_2D_FFT_BACKWARD)
+            if (cplx) call r2r_1m_y(wk2ia, wk2ib, DECOMP_2D_FFT_BACKWARD)
+         end if
+
+         ! Transpose y => z
+         call transpose_y_to_z(wk2rb, wk3ra, dtt_decomp_yz)
+         if (cplx) then
+            call transpose_y_to_z(wk2ib, wk3ia, dtt_decomp_yz)
+         end if
+
+         ! DFT / DTT in z
+         if (cplx) then
+            call rr2r_1m_z(wk3ra, wk3ia, out)
+         else
+            call r2r_1m_z(wk3ra, out, DECOMP_2D_FFT_BACKWARD)
+         end if
+
+      else
+
+         ! DFT / DTT in z
+         if (dtt_z_dft) then
+            if (dtt_y_dft .or. dtt_x_dft) then
+               call rr2rr_1m_z(wk3rb, wk3ib, wk3ra, wk3ia, DECOMP_2D_FFT_BACKWARD)
+            else
+               call rr2r_1m_z(wk3rb, wk3ib, wk3ra)
+               cplx = .false.
+            end if
+         else
+            if (cplx) then
+               call r2r_1m_z(wk3rb, wk3ra, DECOMP_2D_FFT_BACKWARD)
+               call r2r_1m_z(wk3ib, wk3ia, DECOMP_2D_FFT_BACKWARD)
+            else
+               call r2r_1m_z(in_real, wk3ra, DECOMP_2D_FFT_BACKWARD)
+            end if
+         end if
+
+         ! Transpose z => y
+         call transpose_z_to_y(wk3ra, wk2rb, dtt_decomp_yz)
+         if (cplx) then
+            call transpose_z_to_y(wk3ia, wk2ib, dtt_decomp_yz)
+         end if
+
+         ! DFT / DTT in y
+         if (dtt_y_dft) then
+            if (dtt_x_dft) then
+               call rr2rr_1m_y(wk2rb, wk2ib, wk2ra, wk2ia, DECOMP_2D_FFT_BACKWARD)
+            else
+               call rr2r_1m_y(wk2rb, wk2ib, wk2ra)
+               cplx = .false.
+            end if
+         else
+            call r2r_1m_y(wk2rb, wk2ra, DECOMP_2D_FFT_BACKWARD)
+            if (cplx) call r2r_1m_y(wk2ib, wk2ia, DECOMP_2D_FFT_BACKWARD)
+         end if
+
+         ! Transpose y => x
+         call transpose_y_to_x(wk2ra, wk1rb, dtt_decomp_xy)
+         if (cplx) then
+            call transpose_y_to_x(wk2ia, wk1ib, dtt_decomp_xy)
+         end if
+
+         ! DFT / DTT in x
+         if (cplx) then
+            call rr2r_1m_x(wk1rb, wk1ib, out)
+         else
+            call r2r_1m_x(wk1rb, out, DECOMP_2D_FFT_BACKWARD)
+         end if
+
+      end if
+
+      if (decomp_profiler_fft) call decomp_profiler_end("decomp_2d_dtt_3d_x2r")
+
+   end subroutine decomp_2d_dtt_3d_x2r
+
+   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Wrappers for calling 3D FFT directly using the engine object
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    subroutine decomp_2d_fft_engine_fft_c2c(engine, in, out, isign)
@@ -1541,5 +3399,156 @@ contains
       call decomp_2d_fft_3d(in, out)
 
    end subroutine decomp_2d_fft_engine_fft_c2r
+
+   !
+   ! Wrappers are needed for skipping points
+   !
+   subroutine wrapper_rr2rr(plan, &
+                            inr, &
+                            ini, &
+                            ii, ij, ik, isz, &
+                            outr, &
+                            outi, &
+                            oi, oj, ok, osz)
+
+      implicit none
+
+      ! Arguments
+      type(c_ptr), intent(in) :: plan
+      real(mytype), dimension(:, :, :), target, contiguous, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), target, contiguous, intent(out) :: outr, outi
+      integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
+
+      ! Local variables
+      real(mytype), dimension(:), pointer :: inr2, ini2, outr2, outi2
+
+      ! Create 1D pointers starting at the ifirst / ofirst location
+      call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
+      call c_f_pointer(c_loc(ini(ii, ij, ik)), ini2, (/isz/))
+      call c_f_pointer(c_loc(outr(oi, oj, ok)), outr2, (/osz/))
+      call c_f_pointer(c_loc(outi(oi, oj, ok)), outi2, (/osz/))
+
+      ! Perform DFT
+#ifdef DOUBLE_PREC
+      call fftw_execute_split_dft(plan, inr2, ini2, outr2, outi2)
+#else
+      call fftwf_execute_split_dft(plan, inr2, ini2, outr2, outi2)
+#endif
+
+      ! Release pointers
+      nullify (inr2)
+      nullify (ini2)
+      nullify (outr2)
+      nullify (outi2)
+
+   end subroutine wrapper_rr2rr
+   !
+   subroutine wrapper_r2r(plan, &
+                          inr, &
+                          ii, ij, ik, isz, &
+                          outr, &
+                          oi, oj, ok, osz)
+
+      implicit none
+
+      ! Arguments
+      type(c_ptr), intent(in) :: plan
+      real(mytype), dimension(:, :, :), target, contiguous, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), target, contiguous, intent(out) :: outr
+      integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
+
+      ! Local variables
+      real(mytype), dimension(:), pointer :: inr2, outr2
+
+      ! Create 1D pointers starting at the ifirst / ofirst location
+      call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
+      call c_f_pointer(c_loc(outr(oi, oj, ok)), outr2, (/osz/))
+
+      ! Perform DFT
+#ifdef DOUBLE_PREC
+      call fftw_execute_r2r(plan, inr2, outr2)
+#else
+      call fftwf_execute_r2r(plan, inr2, outr2)
+#endif
+
+      ! Release pointers
+      nullify (inr2)
+      nullify (outr2)
+
+   end subroutine wrapper_r2r
+   !
+   subroutine wrapper_rr2r(plan, &
+                           inr, &
+                           ini, &
+                           ii, ij, ik, isz, &
+                           outr, &
+                           oi, oj, ok, osz)
+
+      implicit none
+
+      ! Arguments
+      type(c_ptr), intent(in) :: plan
+      real(mytype), dimension(:, :, :), target, contiguous, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), target, contiguous, intent(out) :: outr
+      integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
+
+      ! Local variables
+      real(mytype), dimension(:), pointer :: inr2, ini2, outr2
+
+      ! Create 1D pointers starting at the ifirst / ofirst location
+      call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
+      call c_f_pointer(c_loc(ini(ii, ij, ik)), ini2, (/isz/))
+      call c_f_pointer(c_loc(outr(oi, oj, ok)), outr2, (/osz/))
+
+      ! Perform DFT
+#ifdef DOUBLE_PREC
+      call fftw_execute_split_dft_c2r(plan, inr2, ini2, outr2)
+#else
+      call fftwf_execute_split_dft_c2r(plan, inr2, ini2, outr2)
+#endif
+
+      ! Release pointers
+      nullify (inr2)
+      nullify (ini2)
+      nullify (outr2)
+
+   end subroutine wrapper_rr2r
+   !
+   subroutine wrapper_r2rr(plan, &
+                           inr, &
+                           ii, ij, ik, isz, &
+                           outr, &
+                           outi, &
+                           oi, oj, ok, osz)
+
+      implicit none
+
+      ! Arguments
+      type(c_ptr), intent(in) :: plan
+      real(mytype), dimension(:, :, :), target, contiguous, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), target, contiguous, intent(out) :: outr, outi
+      integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
+
+      ! Local variables
+      real(mytype), dimension(:), pointer :: inr2, outr2, outi2
+
+      ! Create 1D pointers starting at the ifirst / ofirst location
+      call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
+      call c_f_pointer(c_loc(outr(oi, oj, ok)), outr2, (/osz/))
+      call c_f_pointer(c_loc(outi(oi, oj, ok)), outi2, (/osz/))
+
+      ! Perform DFT
+#ifdef DOUBLE_PREC
+      call fftw_execute_split_dft_r2c(plan, inr2, outr2, outi2)
+#else
+      call fftwf_execute_split_dft_r2c(plan, inr2, outr2, outi2)
+#endif
+
+      ! Release pointers
+      nullify (inr2)
+      nullify (outr2)
+      nullify (outi2)
+
+   end subroutine wrapper_r2rr
 
 end module decomp_2d_fft

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -442,7 +442,7 @@ contains
       if (size(in_DTT) == 12) then
          engine%dtt(1:12) = in_DTT
       elseif (size(in_DTT) == 3) then
-         engine%dtt(1:3) = in_DTT(:)
+         engine%dtt(1:3) = in_DTT
          call dtt_assign_default(engine%dtt)
       else
          call decomp_2d_abort(__FILE__, __LINE__, size(in_DTT), "Invalid argument")

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -2409,10 +2409,6 @@ contains
       real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
       integer, intent(in) :: isign
 
-      ! Local variables
-      type(c_ptr) :: plan
-      integer :: ifirst, ofirst
-
       ! Copy and exit if needed
       if (skip_x_c2c) then
          outr = inr
@@ -2420,26 +2416,15 @@ contains
          return
       end if
 
-      ! Get the DTT config
-      if (isign == DECOMP_2D_FFT_FORWARD) then
-         plan = dtt_plan(1)
-         ifirst = dtt(4)
-         ofirst = dtt(10)
-      else
-         plan = dtt_plan(4)
-         ifirst = dtt(10)
-         ofirst = dtt(4)
-      end if
-
       ! Perform the DFT
       if (isign == DECOMP_2D_FFT_FORWARD) then
-         call wrapper_rr2rr(plan, &
-                            inr, ini, ifirst, 1, 1, size(inr) - ifirst + 1, &
-                            outr, outi, ofirst, 1, 1, size(outr) - ofirst + 1)
+         call wrapper_rr2rr(dtt_plan(1), &
+                            inr, ini, 1, 1, 1, size(inr), &
+                            outr, outi, 1, 1, 1, size(outr))
       else
-         call wrapper_rr2rr(plan, &
-                            ini, inr, ifirst, 1, 1, size(inr) - ifirst + 1, &
-                            outi, outr, ofirst, 1, 1, size(outr) - ofirst + 1)
+         call wrapper_rr2rr(dtt_plan(4), &
+                            ini, inr, 1, 1, 1, size(inr), &
+                            outi, outr, 1, 1, 1, size(outr))
       end if
 
    end subroutine rr2rr_1m_x
@@ -2453,9 +2438,8 @@ contains
       real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
       integer, intent(in) :: isign
 
-      ! Local variables
-      integer :: k, ifirst, ofirst
-      type(c_ptr) :: plan
+      ! Local variable
+      integer :: k
 
       ! Copy and exit if needed
       if (skip_y_c2c) then
@@ -2464,29 +2448,18 @@ contains
          return
       end if
 
-      ! Get the DTT config
-      if (isign == DECOMP_2D_FFT_FORWARD) then
-         plan = dtt_plan(2)
-         ifirst = dtt(5)
-         ofirst = dtt(11)
-      else
-         plan = dtt_plan(5)
-         ifirst = dtt(11)
-         ofirst = dtt(5)
-      end if
-
       ! Perform the DFT
       if (isign == DECOMP_2D_FFT_FORWARD) then
          do k = 1, size(inr, 3)
-            call wrapper_rr2rr(plan, &
-                               inr, ini, 1, ifirst, k, size(inr, 1) * (size(inr, 2) - ifirst + 1), &
-                               outr, outi, 1, ofirst, k, size(outr, 1) * (size(outr, 2) - ofirst + 1))
+            call wrapper_rr2rr(dtt_plan(2), &
+                               inr, ini, 1, 1, k, size(inr, 1) * size(inr, 2), &
+                               outr, outi, 1, 1, k, size(outr, 1) * size(outr, 2))
          end do
       else
          do k = 1, size(inr, 3)
-            call wrapper_rr2rr(plan, &
-                               ini, inr, 1, ifirst, k, size(inr, 1) * (size(inr, 2) - ifirst + 1), &
-                               outi, outr, 1, ofirst, k, size(outr, 1) * (size(outr, 2) - ofirst + 1))
+            call wrapper_rr2rr(dtt_plan(5), &
+                               ini, inr, 1, 1, k, size(inr, 1) * size(inr, 2), &
+                               outi, outr, 1, 1, k, size(outr, 1) * size(outr, 2))
          end do
       end if
 
@@ -2501,10 +2474,6 @@ contains
       real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
       integer, intent(in) :: isign
 
-      ! Local variables
-      type(c_ptr) :: plan
-      integer :: ifirst, ofirst
-
       ! Copy and exit if needed
       if (skip_z_c2c) then
          outr = inr
@@ -2512,26 +2481,15 @@ contains
          return
       end if
 
-      ! Get the DTT config
-      if (isign == DECOMP_2D_FFT_FORWARD) then
-         plan = dtt_plan(3)
-         ifirst = dtt(6)
-         ofirst = dtt(12)
-      else
-         plan = dtt_plan(6)
-         ifirst = dtt(12)
-         ofirst = dtt(6)
-      end if
-
       ! Perform the DFT
       if (isign == DECOMP_2D_FFT_FORWARD) then
-         call wrapper_rr2rr(plan, &
-                            inr, ini, 1, 1, ifirst, size(inr, 1) * size(inr, 2) * (size(inr, 3) - ifirst + 1), &
-                            outr, outi, 1, 1, ofirst, size(outr, 1) * size(outr, 2) * (size(outr, 3) - ofirst + 1))
+         call wrapper_rr2rr(dtt_plan(3), &
+                            inr, ini, 1, 1, 1, size(inr), &
+                            outr, outi, 1, 1, 1, size(outr))
       else
-         call wrapper_rr2rr(plan, &
-                            ini, inr, 1, 1, ifirst, size(inr, 1) * size(inr, 2) * (size(inr, 3) - ifirst + 1), &
-                            outi, outr, 1, 1, ofirst, size(outr, 1) * size(outr, 2) * (size(outr, 3) - ofirst + 1))
+         call wrapper_rr2rr(dtt_plan(6), &
+                            ini, inr, 1, 1, 1, size(inr), &
+                            outi, outr, 1, 1, 1, size(outr))
       end if
 
    end subroutine rr2rr_1m_z
@@ -2659,8 +2617,8 @@ contains
 
       ! Perform the DFT
       call wrapper_rr2r(dtt_plan(4), &
-                        inr, ini, dtt(10), 1, 1, size(inr) - dtt(10) + 1, &
-                        outr, dtt(4), 1, 1, size(outr) - dtt(4) + 1)
+                        inr, ini, 1, 1, 1, size(inr), &
+                        outr, 1, 1, 1, size(outr))
 
    end subroutine rr2r_1m_x
 
@@ -2677,8 +2635,8 @@ contains
       ! Perform the DFT
       do k = 1, size(inr, 3)
          call wrapper_rr2r(dtt_plan(5), &
-                           inr, ini, 1, dtt(11), k, size(inr, 1) * (size(inr, 2) - dtt(11) + 1), &
-                           outr, 1, dtt(5), k, size(outr, 1) * (size(outr, 2) - dtt(5) + 1))
+                           inr, ini, 1, 1, k, size(inr, 1) * size(inr, 2), &
+                           outr, 1, 1, k, size(outr, 1) * size(outr, 2))
       end do
 
    end subroutine rr2r_1m_y
@@ -2693,8 +2651,8 @@ contains
 
       ! Perform the DFT
       call wrapper_rr2r(dtt_plan(6), &
-                        inr, ini, 1, 1, dtt(12), size(inr, 1) * size(inr, 2) * (size(inr, 3) - dtt(12) + 1), &
-                        outr, 1, 1, dtt(6), size(outr, 1) * size(outr, 2) * (size(outr, 3) - dtt(6) + 1))
+                        inr, ini, 1, 1, 1, size(inr), &
+                        outr, 1, 1, 1, size(outr))
 
    end subroutine rr2r_1m_z
 
@@ -2708,8 +2666,8 @@ contains
 
       ! Perform the DFT
       call wrapper_r2rr(dtt_plan(1), &
-                        inr, dtt(4), 1, 1, size(inr) - dtt(4) + 1, &
-                        outr, outi, dtt(10), 1, 1, size(outr) - dtt(10) + 1)
+                        inr, 1, 1, 1, size(inr), &
+                        outr, outi, 1, 1, 1, size(outr))
 
    end subroutine r2rr_1m_x
 
@@ -2726,8 +2684,8 @@ contains
       ! Perform the DFT
       do k = 1, size(inr, 3)
          call wrapper_r2rr(dtt_plan(2), &
-                           inr, 1, dtt(5), k, size(inr, 1) * (size(inr, 2) - dtt(5) + 1), &
-                           outr, outi, 1, dtt(11), k, size(outr, 1) * (size(outr, 2) - dtt(11) + 1))
+                           inr, 1, 1, k, size(inr, 1) * size(inr, 2), &
+                           outr, outi, 1, 1, k, size(outr, 1) * size(outr, 2))
       end do
 
    end subroutine r2rr_1m_y
@@ -2742,8 +2700,8 @@ contains
 
       ! Perform the DFT
       call wrapper_r2rr(dtt_plan(3), &
-                        inr, 1, 1, dtt(6), size(inr, 1) * size(inr, 2) * (size(inr, 3) - dtt(6) + 1), &
-                        outr, outi, 1, 1, dtt(12), size(outr, 1) * size(outr, 2) * (size(outr, 3) - dtt(12) + 1))
+                        inr, 1, 1, 1, size(inr), &
+                        outr, outi, 1, 1, 1, size(outr))
 
    end subroutine r2rr_1m_z
 

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -1551,7 +1551,7 @@ contains
       type(fftwf_iodim) :: dims(1), howmany(1)
 #endif
 
-      sz = product(decomp%xsz) - ndismiss
+      sz = product(decomp%xsz)
       a1_p = fftw_alloc_real(sz)
       a2_p = fftw_alloc_real(sz)
       a3_p = fftw_alloc_real(sz)
@@ -1613,7 +1613,7 @@ contains
       type(fftwf_iodim) :: dims(1), howmany(1)
 #endif
 
-      sz = decomp%ysz(1) * (decomp%ysz(2) - ndismiss)
+      sz = decomp%ysz(1) * decomp%ysz(2)
       a1_p = fftw_alloc_real(sz)
       a2_p = fftw_alloc_real(sz)
       a3_p = fftw_alloc_real(sz)

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -653,88 +653,88 @@ contains
    end subroutine decomp_2d_fft_engine_dtt_init
 
    ! Set default values in the DTT config
-   subroutine dtt_assign_default(dtt)
+   subroutine dtt_assign_default(arg_dtt)
 
       implicit none
 
-      integer, intent(inout) :: dtt(15)
+      integer, intent(inout) :: arg_dtt(15)
 
       integer :: k
 
       ! Generic values
       ! ifirst = 1, use the array from the beginning
-      dtt(4:6) = 1
+      arg_dtt(4:6) = 1
       ! ndismiss = 1, skip one point
-      dtt(7:9) = 1
+      arg_dtt(7:9) = 1
 
       ! Specific cases
       do k = 1, 3
-         if (dtt(k) == 0) dtt(k + 6) = 0 ! Periodic, ndismiss = 0
-         if (dtt(k) == 1) dtt(k + 6) = 0 ! DCT1, ndismiss = 0
-         if (dtt(k) == 5) dtt(k + 3) = 2 ! DST1, ifirst = 2
-         if (dtt(k) == 5) dtt(k + 6) = 2 ! DST1, ndismiss = 2
-         if (dtt(k) == 7) dtt(k + 3) = 2 ! DST3, ifirst = 2
+         if (arg_dtt(k) == 0) arg_dtt(k + 6) = 0 ! Periodic, ndismiss = 0
+         if (arg_dtt(k) == 1) arg_dtt(k + 6) = 0 ! DCT1, ndismiss = 0
+         if (arg_dtt(k) == 5) arg_dtt(k + 3) = 2 ! DST1, ifirst = 2
+         if (arg_dtt(k) == 5) arg_dtt(k + 6) = 2 ! DST1, ndismiss = 2
+         if (arg_dtt(k) == 7) arg_dtt(k + 3) = 2 ! DST3, ifirst = 2
       end do
 
       ! ofirst = ifirst
-      dtt(10:12) = dtt(4:6)
+      arg_dtt(10:12) = arg_dtt(4:6)
 
    end subroutine dtt_assign_default
 
    ! Set the backward transforms in the DTT config
-   subroutine dtt_invert(dtt)
+   subroutine dtt_invert(arg_dtt)
 
       implicit none
 
-      integer, intent(inout) :: dtt(15)
+      integer, intent(inout) :: arg_dtt(15)
 
       integer :: k
 
       ! Default : inv(DTT) = DTT
-      dtt(13:15) = dtt(1:3)
+      arg_dtt(13:15) = arg_dtt(1:3)
 
       ! Except for DCT2, DCT3, DST2, DST3
       do k = 1, 3
-         if (dtt(k) == 0) dtt(12 + k) = 9
-         if (dtt(k) == 2) dtt(12 + k) = 3 ! inv(DCT2) = DCT3
-         if (dtt(k) == 3) dtt(12 + k) = 2 ! inv(DCT3) = DCT2
-         if (dtt(k) == 6) dtt(12 + k) = 7 ! inv(DST2) = DST3
-         if (dtt(k) == 7) dtt(12 + k) = 6 ! inv(DST3) = DST2
+         if (arg_dtt(k) == 0) arg_dtt(12 + k) = 9
+         if (arg_dtt(k) == 2) arg_dtt(12 + k) = 3 ! inv(DCT2) = DCT3
+         if (arg_dtt(k) == 3) arg_dtt(12 + k) = 2 ! inv(DCT3) = DCT2
+         if (arg_dtt(k) == 6) arg_dtt(12 + k) = 7 ! inv(DST2) = DST3
+         if (arg_dtt(k) == 7) arg_dtt(12 + k) = 6 ! inv(DST3) = DST2
       end do
 
    end subroutine dtt_invert
 
    ! Adapt the DTT type to FFTW
-   subroutine dtt_for_fftw(dtt)
+   subroutine dtt_for_fftw(arg_dtt)
 
       implicit none
 
-      integer, intent(inout) :: dtt(:)
+      integer, intent(inout) :: arg_dtt(:)
 
       integer :: k
 
-      do k = 1, size(dtt)
-         select case (dtt(k))
+      do k = 1, size(arg_dtt)
+         select case (arg_dtt(k))
          case (0)
-            dtt(k) = FFTW_FORWARD
+            arg_dtt(k) = FFTW_FORWARD
          case (1)
-            dtt(k) = FFTW_REDFT00
+            arg_dtt(k) = FFTW_REDFT00
          case (2)
-            dtt(k) = FFTW_REDFT10
+            arg_dtt(k) = FFTW_REDFT10
          case (3)
-            dtt(k) = FFTW_REDFT01
+            arg_dtt(k) = FFTW_REDFT01
          case (4)
-            dtt(k) = FFTW_REDFT11
+            arg_dtt(k) = FFTW_REDFT11
          case (5)
-            dtt(k) = FFTW_RODFT00
+            arg_dtt(k) = FFTW_RODFT00
          case (6)
-            dtt(k) = FFTW_RODFT10
+            arg_dtt(k) = FFTW_RODFT10
          case (7)
-            dtt(k) = FFTW_RODFT01
+            arg_dtt(k) = FFTW_RODFT01
          case (8)
-            dtt(k) = FFTW_RODFT11
+            arg_dtt(k) = FFTW_RODFT11
          case (9)
-            dtt(k) = FFTW_BACKWARD
+            arg_dtt(k) = FFTW_BACKWARD
          end select
       end do
 

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -648,7 +648,7 @@ contains
          end if
       end if
       do i = 1, 6
-         if (.not.c_associated(engine%dtt_plan(i))) call decomp_2d_abort(__FILE__, __LINE__, i, "DTT plan creation failed")
+         if (.not. c_associated(engine%dtt_plan(i))) call decomp_2d_abort(__FILE__, __LINE__, i, "DTT plan creation failed")
       end do
 
    end subroutine decomp_2d_fft_engine_dtt_init

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -2084,7 +2084,7 @@ contains
 #ifdef DOUBLE_PREC
       plan = fftw_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), &
 #else
-      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), & !&
+      plan = fftwf_plan_many_r2r(1, ntmp(1), decomp%xsz(2) * decomp%xsz(3), &
 #endif
                                  a1, decomp%xsz(1), 1, decomp%xsz(1), &
                                  a2, decomp%xsz(1), 1, decomp%xsz(1), &

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -1539,7 +1539,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p, a4_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = product(decomp%xsz) - ndismiss
       a1_p = fftw_alloc_real(sz)
@@ -1597,7 +1601,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p, a4_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = decomp%ysz(1) * (decomp%ysz(2) - ndismiss)
       a1_p = fftw_alloc_real(sz)
@@ -1655,7 +1663,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p, a4_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = product(decomp%zsz)
       a1_p = fftw_alloc_real(sz)
@@ -1711,7 +1723,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = product(decomp%xsz)
       a1_p = fftw_alloc_real(sz)
@@ -1764,7 +1780,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = decomp%ysz(1) * decomp%ysz(2)
       a1_p = fftw_alloc_real(sz)
@@ -1817,7 +1837,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = product(decomp%zsz)
       a1_p = fftw_alloc_real(sz)
@@ -1870,7 +1894,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = product(decomp%xsz)
       a1_p = fftw_alloc_real(sz)
@@ -1923,7 +1951,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = decomp%ysz(1) * decomp%ysz(2)
       a1_p = fftw_alloc_real(sz)
@@ -1976,7 +2008,11 @@ contains
 #endif
       type(C_PTR) :: a1_p, a2_p, a3_p
       integer(C_SIZE_T) :: sz
+#ifdef DOUBLE_PREC
       type(fftw_iodim) :: dims(1), howmany(1)
+#else
+      type(fftwf_iodim) :: dims(1), howmany(1)
+#endif
 
       sz = product(decomp%zsz)
       a1_p = fftw_alloc_real(sz)

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -18,7 +18,8 @@ module decomp_2d_fft
    private        ! Make everything private unless declared public
 
    ! engine-specific global variables
-   integer, save :: plan_type = FFTW_MEASURE
+   integer, parameter :: plan_type = FFTW_MEASURE
+   integer, parameter :: plan_type_dtt = FFTW_MEASURE + FFTW_UNALIGNED
 
    ! FFTW plans
    ! j=1,2,3 corresponds to the 1D FFTs in X,Y,Z direction, respectively
@@ -1568,9 +1569,9 @@ contains
       howmany(1)%is = decomp%xsz(1)
       howmany(1)%os = decomp%xsz(1)
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1630,9 +1631,9 @@ contains
       howmany(1)%is = 1
       howmany(1)%os = 1
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1692,9 +1693,9 @@ contains
       howmany(1)%is = 1
       howmany(1)%os = 1
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+      plan = fftw_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type)
+      plan = fftwf_plan_guru_split_dft(1, dims(1), 1, howmany(1), a1, a2, a3, a4, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1751,9 +1752,9 @@ contains
       howmany(1)%is = decomp%xsz(1)
       howmany(1)%os = decomp2%xsz(1)
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1808,9 +1809,9 @@ contains
       howmany(1)%is = 1
       howmany(1)%os = 1
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1865,9 +1866,9 @@ contains
       howmany(1)%is = 1
       howmany(1)%os = 1
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftw_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftwf_plan_guru_split_dft_c2r(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1922,9 +1923,9 @@ contains
       howmany(1)%is = decomp%xsz(1)
       howmany(1)%os = decomp2%xsz(1)
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -1979,9 +1980,9 @@ contains
       howmany(1)%is = 1
       howmany(1)%os = 1
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -2036,9 +2037,9 @@ contains
       howmany(1)%is = 1
       howmany(1)%os = 1
 #ifdef DOUBLE_PREC
-      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftw_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #else
-      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type)
+      plan = fftwf_plan_guru_split_dft_r2c(1, dims(1), 1, howmany(1), a1, a2, a3, plan_type_dtt)
 #endif
 
       call fftw_free(a1_p)
@@ -2088,7 +2089,7 @@ contains
 #endif
                                  a1, decomp%xsz(1), 1, decomp%xsz(1), &
                                  a2, decomp%xsz(1), 1, decomp%xsz(1), &
-                                 tmp(1), plan_type)
+                                 tmp(1), plan_type_dtt)
 
       call fftw_free(a1_p)
       call fftw_free(a2_p)
@@ -2135,7 +2136,7 @@ contains
 #endif
                                  a1, decomp%ysz(2), decomp%ysz(1), 1, &
                                  a2, decomp%ysz(2), decomp%ysz(1), 1, &
-                                 tmp(1), plan_type)
+                                 tmp(1), plan_type_dtt)
 
       call fftw_free(a1_p)
       call fftw_free(a2_p)
@@ -2182,7 +2183,7 @@ contains
 #endif
                                  a1, decomp%zsz(3), decomp%zsz(1) * decomp%zsz(2), 1, &
                                  a2, decomp%zsz(3), decomp%zsz(1) * decomp%zsz(2), 1, &
-                                 tmp(1), plan_type)
+                                 tmp(1), plan_type_dtt)
 
       call fftw_free(a1_p)
       call fftw_free(a2_p)

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -2415,8 +2415,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
-      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
       integer, intent(in) :: isign
 
       ! Local variables
@@ -2463,8 +2463,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
-      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
       integer, intent(in) :: isign
 
       ! Local variables
@@ -2507,8 +2507,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr
-      real(mytype), dimension(:, :, :), intent(out) :: outr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr
       integer, intent(in) :: isign
 
       ! Local variables
@@ -2544,8 +2544,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr
-      real(mytype), dimension(:, :, :), intent(out) :: outr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr
       integer, intent(in) :: isign
 
       ! Local variables
@@ -2583,8 +2583,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr
-      real(mytype), dimension(:, :, :), intent(out) :: outr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr
       integer, intent(in) :: isign
 
       ! Local variables
@@ -2620,8 +2620,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
-      real(mytype), dimension(:, :, :), intent(out) :: outr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr
 
       ! Perform the DFT
       call wrapper_rr2r(dtt_plan(4), &
@@ -2635,8 +2635,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
-      real(mytype), dimension(:, :, :), intent(out) :: outr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr
 
       integer :: k
 
@@ -2654,8 +2654,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr, ini
-      real(mytype), dimension(:, :, :), intent(out) :: outr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr, ini
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr
 
       ! Perform the DFT
       call wrapper_rr2r(dtt_plan(6), &
@@ -2669,8 +2669,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr
-      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
 
       ! Perform the DFT
       call wrapper_r2rr(dtt_plan(1), &
@@ -2684,8 +2684,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr
-      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
 
       integer :: k
 
@@ -2703,8 +2703,8 @@ contains
 
       implicit none
 
-      real(mytype), dimension(:, :, :), intent(inout) :: inr
-      real(mytype), dimension(:, :, :), intent(out) :: outr, outi
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: inr
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out) :: outr, outi
 
       ! Perform the DFT
       call wrapper_r2rr(dtt_plan(3), &
@@ -3033,9 +3033,9 @@ contains
       implicit none
 
       ! Arguments
-      real(mytype), dimension(:, :, :), intent(inout) :: in
-      real(mytype), dimension(:, :, :), intent(out), optional :: out_real
-      complex(mytype), dimension(:, :, :), intent(out), optional :: out_cplx
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout) :: in
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out), optional :: out_real
+      complex(mytype), dimension(:, :, :), contiguous, target, intent(out), optional :: out_cplx
 
       ! Local variables
       logical :: cplx
@@ -3200,9 +3200,9 @@ contains
       implicit none
 
       ! Arguments
-      real(mytype), dimension(:, :, :), intent(inout), optional :: in_real
-      complex(mytype), dimension(:, :, :), intent(inout), optional :: in_cplx
-      real(mytype), dimension(:, :, :), intent(out), optional :: out
+      real(mytype), dimension(:, :, :), contiguous, target, intent(inout), optional :: in_real
+      complex(mytype), dimension(:, :, :), contiguous, target, intent(inout), optional :: in_cplx
+      real(mytype), dimension(:, :, :), contiguous, target, intent(out), optional :: out
 
       ! Local variables
       logical :: cplx

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -422,6 +422,7 @@ contains
       class(decomp_2d_fft_engine), intent(inout), target :: engine
       integer, dimension(:), intent(in) :: in_DTT
 
+      integer :: i
       integer(C_SIZE_T) :: sz
 
       ! Safety check
@@ -573,6 +574,7 @@ contains
       engine%wk3ib = 0._mytype
 
       ! Prepare the fftw plans
+      engine%dtt_plan = c_null_ptr
       if (engine%format == PHYSICAL_IN_X) then
          ! in x
          if (engine%dtt(1) == FFTW_FORWARD) then
@@ -644,6 +646,9 @@ contains
             call r2r_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt(13), engine%dtt(7))
          end if
       end if
+      do i = 1, 6
+         if (.not.c_associated(engine%dtt_plan(i))) call decomp_2d_abort(__FILE__, __LINE__, i, "DTT plan creation failed")
+      end do
 
    end subroutine decomp_2d_fft_engine_dtt_init
 
@@ -890,6 +895,7 @@ contains
          call fftwf_destroy_plan(engine%dtt_plan(i))
 #endif
       end do
+      engine%dtt_plan = c_null_ptr
 
    end subroutine decomp_2d_fft_engine_dtt_fin
 

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -3462,7 +3462,7 @@ contains
       integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
 
       ! Local variables
-      real(mytype), dimension(:), pointer :: inr2, ini2, outr2, outi2
+      real(mytype), dimension(:), contiguous, pointer :: inr2, ini2, outr2, outi2
 
       ! Create 1D pointers starting at the ifirst / ofirst location
       call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
@@ -3500,7 +3500,7 @@ contains
       integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
 
       ! Local variables
-      real(mytype), dimension(:), pointer :: inr2, outr2
+      real(mytype), dimension(:), contiguous, pointer :: inr2, outr2
 
       ! Create 1D pointers starting at the ifirst / ofirst location
       call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
@@ -3535,7 +3535,7 @@ contains
       integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
 
       ! Local variables
-      real(mytype), dimension(:), pointer :: inr2, ini2, outr2
+      real(mytype), dimension(:), contiguous, pointer :: inr2, ini2, outr2
 
       ! Create 1D pointers starting at the ifirst / ofirst location
       call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))
@@ -3572,7 +3572,7 @@ contains
       integer, intent(in) :: ii, ij, ik, isz, oi, oj, ok, osz
 
       ! Local variables
-      real(mytype), dimension(:), pointer :: inr2, outr2, outi2
+      real(mytype), dimension(:), contiguous, pointer :: inr2, outr2, outi2
 
       ! Create 1D pointers starting at the ifirst / ofirst location
       call c_f_pointer(c_loc(inr(ii, ij, ik)), inr2, (/isz/))

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -579,8 +579,8 @@ contains
       if (engine%format == PHYSICAL_IN_X) then
          ! in x
          if (engine%dtt(1) == FFTW_FORWARD) then
-            call r2rr_1m_x_plan(engine%dtt_plan(1), engine%ph, engine%sp, engine%dtt(7))
-            call rr2r_1m_x_plan(engine%dtt_plan(4), engine%sp, engine%ph, engine%dtt(7))
+            call r2rr_1m_x_plan(engine%dtt_plan(1), engine%ph, engine%sp)
+            call rr2r_1m_x_plan(engine%dtt_plan(4), engine%sp, engine%ph)
          else
             call r2r_1m_x_plan(engine%dtt_plan(1), engine%ph, engine%dtt(1), engine%dtt(7))
             call r2r_1m_x_plan(engine%dtt_plan(4), engine%ph, engine%dtt(13), engine%dtt(7))
@@ -588,11 +588,11 @@ contains
          ! in y
          if (engine%dtt(2) == FFTW_FORWARD) then
             if (engine%dtt(1) == FFTW_FORWARD) then
-               call rr2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(8))
-               call rr2rr_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt(8)) ! Duplicated plan, this can be improved
+               call rr2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy)
+               call rr2rr_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy) ! Duplicated plan, this can be improved
             else
-               call r2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt_decomp_yz, engine%dtt(8))
-               call rr2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_yz, engine%dtt_decomp_xy, engine%dtt(8))
+               call r2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt_decomp_yz)
+               call rr2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_yz, engine%dtt_decomp_xy)
             end if
          else
             call r2r_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(2), engine%dtt(8))
@@ -601,11 +601,11 @@ contains
          ! in z
          if (engine%dtt(3) == FFTW_FORWARD) then
             if (engine%dtt(1) == FFTW_FORWARD .or. engine%dtt(2) == FFTW_FORWARD) then
-               call rr2rr_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_sp, engine%dtt(9))
-               call rr2rr_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp, engine%dtt(9)) ! Duplicated plan, this can be improved
+               call rr2rr_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_sp)
+               call rr2rr_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp) ! Duplicated plan, this can be improved
             else
-               call r2rr_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_yz, engine%dtt_decomp_sp, engine%dtt(9))
-               call rr2r_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp, engine%dtt_decomp_yz, engine%dtt(9))
+               call r2rr_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_yz, engine%dtt_decomp_sp)
+               call rr2r_1m_z_plan(engine%dtt_plan(6), engine%dtt_decomp_sp, engine%dtt_decomp_yz)
             end if
          else
             call r2r_1m_z_plan(engine%dtt_plan(3), engine%dtt_decomp_sp, engine%dtt(3), engine%dtt(9))
@@ -614,8 +614,8 @@ contains
       else
          ! in z
          if (engine%dtt(3) == FFTW_FORWARD) then
-            call r2rr_1m_z_plan(engine%dtt_plan(3), engine%ph, engine%sp, engine%dtt(9))
-            call rr2r_1m_z_plan(engine%dtt_plan(6), engine%sp, engine%ph, engine%dtt(9))
+            call r2rr_1m_z_plan(engine%dtt_plan(3), engine%ph, engine%sp)
+            call rr2r_1m_z_plan(engine%dtt_plan(6), engine%sp, engine%ph)
          else
             call r2r_1m_z_plan(engine%dtt_plan(3), engine%ph, engine%dtt(3), engine%dtt(9))
             call r2r_1m_z_plan(engine%dtt_plan(6), engine%ph, engine%dtt(15), engine%dtt(9))
@@ -623,11 +623,11 @@ contains
          ! in y
          if (engine%dtt(2) == FFTW_FORWARD) then
             if (engine%dtt(3) == FFTW_FORWARD) then
-               call rr2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(8))
-               call rr2rr_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt(8)) ! Duplicated plan, this can be improved
+               call rr2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy)
+               call rr2rr_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy) ! Duplicated plan, this can be improved
             else
-               call r2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_yz, engine%dtt_decomp_xy, engine%dtt(8))
-               call rr2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt_decomp_yz, engine%dtt(8))
+               call r2rr_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_yz, engine%dtt_decomp_xy)
+               call rr2r_1m_y_plan(engine%dtt_plan(5), engine%dtt_decomp_xy, engine%dtt_decomp_yz)
             end if
          else
             call r2r_1m_y_plan(engine%dtt_plan(2), engine%dtt_decomp_xy, engine%dtt(2), engine%dtt(8))
@@ -636,11 +636,11 @@ contains
          ! in x
          if (engine%dtt(1) == FFTW_FORWARD) then
             if (engine%dtt(2) == FFTW_FORWARD .or. engine%dtt(3) == FFTW_FORWARD) then
-               call rr2rr_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_sp, engine%dtt(7))
-               call rr2rr_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt(7)) ! Duplicated plan, this can be improved
+               call rr2rr_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_sp)
+               call rr2rr_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp) ! Duplicated plan, this can be improved
             else
-               call r2rr_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_xy, engine%dtt_decomp_sp, engine%dtt(7))
-               call rr2r_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt_decomp_xy, engine%dtt(7))
+               call r2rr_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_xy, engine%dtt_decomp_sp)
+               call rr2r_1m_x_plan(engine%dtt_plan(4), engine%dtt_decomp_sp, engine%dtt_decomp_xy)
             end if
          else
             call r2r_1m_x_plan(engine%dtt_plan(1), engine%dtt_decomp_sp, engine%dtt(1), engine%dtt(7))
@@ -1524,13 +1524,12 @@ contains
    end subroutine c2r_1m_z_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
-   subroutine rr2rr_1m_x_plan(plan, decomp, ndismiss)
+   subroutine rr2rr_1m_x_plan(plan, decomp)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1562,7 +1561,7 @@ contains
       call c_f_pointer(a3_p, a3, decomp%xsz)
       call c_f_pointer(a4_p, a4, decomp%xsz)
 
-      dims(1)%n = decomp%xsz(1) - ndismiss
+      dims(1)%n = decomp%xsz(1)
       dims(1)%is = 1
       dims(1)%os = 1
       howmany(1)%n = decomp%xsz(2) * decomp%xsz(3)
@@ -1586,13 +1585,12 @@ contains
    end subroutine rr2rr_1m_x_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
-   subroutine rr2rr_1m_y_plan(plan, decomp, ndismiss)
+   subroutine rr2rr_1m_y_plan(plan, decomp)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1624,7 +1622,7 @@ contains
       call c_f_pointer(a3_p, a3, (/decomp%ysz(1), decomp%ysz(2)/))
       call c_f_pointer(a4_p, a4, (/decomp%ysz(1), decomp%ysz(2)/))
 
-      dims(1)%n = decomp%ysz(2) - ndismiss
+      dims(1)%n = decomp%ysz(2)
       dims(1)%is = decomp%ysz(1)
       dims(1)%os = decomp%ysz(1)
       howmany(1)%n = decomp%ysz(1)
@@ -1648,13 +1646,12 @@ contains
    end subroutine rr2rr_1m_y_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
-   subroutine rr2rr_1m_z_plan(plan, decomp, ndismiss)
+   subroutine rr2rr_1m_z_plan(plan, decomp)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1686,7 +1683,7 @@ contains
       call c_f_pointer(a3_p, a3, decomp%zsz)
       call c_f_pointer(a4_p, a4, decomp%zsz)
 
-      dims(1)%n = decomp%zsz(3) - ndismiss
+      dims(1)%n = decomp%zsz(3)
       dims(1)%is = decomp%zsz(1) * decomp%zsz(2)
       dims(1)%os = decomp%zsz(1) * decomp%zsz(2)
       howmany(1)%n = decomp%zsz(1) * decomp%zsz(2)
@@ -1710,13 +1707,12 @@ contains
    end subroutine rr2rr_1m_z_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
-   subroutine rr2r_1m_x_plan(plan, decomp, decomp2, ndismiss)
+   subroutine rr2r_1m_x_plan(plan, decomp, decomp2)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1745,7 +1741,7 @@ contains
       call c_f_pointer(a2_p, a2, decomp%xsz)
       call c_f_pointer(a3_p, a3, decomp2%xsz)
 
-      dims(1)%n = decomp2%xsz(1) - ndismiss
+      dims(1)%n = decomp2%xsz(1)
       dims(1)%is = 1
       dims(1)%os = 1
       howmany(1)%n = decomp%xsz(2) * decomp%xsz(3)
@@ -1767,13 +1763,12 @@ contains
    end subroutine rr2r_1m_x_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
-   subroutine rr2r_1m_y_plan(plan, decomp, decomp2, ndismiss)
+   subroutine rr2r_1m_y_plan(plan, decomp, decomp2)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1802,7 +1797,7 @@ contains
       call c_f_pointer(a2_p, a2, (/decomp%ysz(1), decomp%ysz(2)/))
       call c_f_pointer(a3_p, a3, (/decomp2%ysz(1), decomp2%ysz(2)/))
 
-      dims(1)%n = decomp2%ysz(2) - ndismiss
+      dims(1)%n = decomp2%ysz(2)
       dims(1)%is = decomp%ysz(1)
       dims(1)%os = decomp2%ysz(1)
       howmany(1)%n = decomp%ysz(1)
@@ -1824,13 +1819,12 @@ contains
    end subroutine rr2r_1m_y_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
-   subroutine rr2r_1m_z_plan(plan, decomp, decomp2, ndismiss)
+   subroutine rr2r_1m_z_plan(plan, decomp, decomp2)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1859,7 +1853,7 @@ contains
       call c_f_pointer(a2_p, a2, decomp%zsz)
       call c_f_pointer(a3_p, a3, decomp2%zsz)
 
-      dims(1)%n = decomp2%zsz(3) - ndismiss
+      dims(1)%n = decomp2%zsz(3)
       dims(1)%is = decomp%zsz(1) * decomp%zsz(2)
       dims(1)%os = decomp2%zsz(1) * decomp2%zsz(2)
       howmany(1)%n = decomp%zsz(1) * decomp%zsz(2)
@@ -1881,13 +1875,12 @@ contains
    end subroutine rr2r_1m_z_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in X direction, with possibility to dismiss points
-   subroutine r2rr_1m_x_plan(plan, decomp, decomp2, ndismiss)
+   subroutine r2rr_1m_x_plan(plan, decomp, decomp2)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1916,7 +1909,7 @@ contains
       call c_f_pointer(a2_p, a2, decomp2%xsz)
       call c_f_pointer(a3_p, a3, decomp2%xsz)
 
-      dims(1)%n = decomp%xsz(1) - ndismiss
+      dims(1)%n = decomp%xsz(1)
       dims(1)%is = 1
       dims(1)%os = 1
       howmany(1)%n = decomp%xsz(2) * decomp%xsz(3)
@@ -1938,13 +1931,12 @@ contains
    end subroutine r2rr_1m_x_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in Y direction, with possibility to dismiss points
-   subroutine r2rr_1m_y_plan(plan, decomp, decomp2, ndismiss)
+   subroutine r2rr_1m_y_plan(plan, decomp, decomp2)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -1973,7 +1965,7 @@ contains
       call c_f_pointer(a2_p, a2, (/decomp2%ysz(1), decomp2%ysz(2)/))
       call c_f_pointer(a3_p, a3, (/decomp2%ysz(1), decomp2%ysz(2)/))
 
-      dims(1)%n = decomp%ysz(2) - ndismiss
+      dims(1)%n = decomp%ysz(2)
       dims(1)%is = decomp%ysz(1)
       dims(1)%os = decomp2%ysz(1)
       howmany(1)%n = decomp%ysz(1)
@@ -1995,13 +1987,12 @@ contains
    end subroutine r2rr_1m_y_plan
 
    ! Return a FFTW3 plan for multiple 1D DTTs in Z direction, with possibility to dismiss points
-   subroutine r2rr_1m_z_plan(plan, decomp, decomp2, ndismiss)
+   subroutine r2rr_1m_z_plan(plan, decomp, decomp2)
 
       implicit none
 
       type(C_PTR), intent(out) :: plan
       TYPE(DECOMP_INFO), intent(in) :: decomp, decomp2
-      integer, intent(in) :: ndismiss  ! to dismiss n points from the signal
 
       ! Local variables
 #ifdef DOUBLE_PREC
@@ -2030,7 +2021,7 @@ contains
       call c_f_pointer(a2_p, a2, decomp2%zsz)
       call c_f_pointer(a3_p, a3, decomp2%zsz)
 
-      dims(1)%n = decomp%zsz(3) - ndismiss
+      dims(1)%n = decomp%zsz(3)
       dims(1)%is = decomp%zsz(1) * decomp%zsz(2)
       dims(1)%os = decomp2%zsz(1) * decomp2%zsz(2)
       howmany(1)%n = decomp%zsz(1) * decomp%zsz(2)

--- a/src/io_adios_none.f90
+++ b/src/io_adios_none.f90
@@ -18,7 +18,7 @@ module decomp_2d_io_adios
 
    implicit none
 
-   ! The external code can use this variable to check if adios2 is available                         
+   ! The external code can use this variable to check if adios2 is available
    logical, parameter, public :: decomp_2d_with_adios2 = .false.
 
    private

--- a/src/io_mpi.f90
+++ b/src/io_mpi.f90
@@ -931,7 +931,7 @@ contains
 
       ! Update displacement for the next write operation
       io%disp = io%disp + product(int(sizes, kind=MPI_OFFSET_KIND)) &
-             * int(type_bytes, kind=MPI_OFFSET_KIND)
+                * int(type_bytes, kind=MPI_OFFSET_KIND)
 
    end subroutine read_or_write
 


### PR DESCRIPTION
Same PR compared with https://github.com/2decomp-fft/2decomp-fft/pull/348 except there is no periodicity

This PR is a sketch for adding support for DCT / DST in the FFT backend fftw_f03.

Each direction (x, y and z) can have periodicity, DCT1, DCT2, DCT3, DCT4, DST1, DST2, DST3, or DST4.

CI tests are added to test the 9**3 = 729 combinations for both physical in x and physical in z input.

This draft PR was elaborated in collaboration with Lionel Gelebart.