### PR TITLE
Fix main

### DIFF
--- a/.github/workflows/RunnerFastCI.yml
+++ b/.github/workflows/RunnerFastCI.yml
@@ -77,7 +77,7 @@ jobs:
         source ~/.bash_aliases
         ml tbb
         ml compiler-rt
-        ml oclfpga
+        ml umf
         ml compiler
         ml mpi
         ml mkl

--- a/.github/workflows/RunnerFullCI.yml
+++ b/.github/workflows/RunnerFullCI.yml
@@ -197,7 +197,7 @@ jobs:
         source ~/.bash_aliases
         ml tbb
         ml compiler-rt
-        ml oclfpga
+        ml umf
         ml compiler
         ml mpi
         ml mkl
@@ -218,7 +218,7 @@ jobs:
         source ~/.bash_aliases
         ml tbb
         ml compiler-rt
-        ml oclfpga
+        ml umf
         ml compiler
         ml mpi
         ml mkl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)                        
+cmake_minimum_required(VERSION 3.20)                        
 cmake_policy(SET CMP0074 NEW)
 
 project(decomp2d

--- a/src/decomp_2d_nccl.f90
+++ b/src/decomp_2d_nccl.f90
@@ -8,6 +8,7 @@ module decomp_2d_nccl
    use decomp_2d_constants
    use decomp_2d_mpi
    use decomp_2d_cumpi
+   use cudafor 
    use nccl
 
    implicit none


### PR DESCRIPTION
Fix inconsistency with CMake version between 2DECOMP&FFT and Xcompact3d. 
This PR fix also a new issues with CUDA 12.4 and above (NVHPC 23.5 and above) where some cuda functions are no more available under the nccl module.  