### PR TITLE
Set decomp_2d_comm to MPI_COMM_NULL when the module is finalized

### DIFF
--- a/src/decomp_2d_mpi.f90
+++ b/src/decomp_2d_mpi.f90
@@ -87,6 +87,7 @@ contains
 
       nrank = -1
       nproc = -1
+      decomp_2d_comm = MPI_COMM_NULL
 
    end subroutine decomp_2d_mpi_fin
 


### PR DESCRIPTION
2decomp should not call MPI_COMM_FREE on the provided communicator

Minor modification, no update of the changelog.