### PR TITLE
Fix OpenMP compilation with new Cray compilers

### DIFF
--- a/cmake/compilers/D2D_flags_cray.cmake
+++ b/cmake/compilers/D2D_flags_cray.cmake
@@ -1,5 +1,5 @@
 #Compilers Flags for Cray
 
-set(D2D_FFLAGS "-eF -g -N 1023 -M878")
+set(D2D_FFLAGS "-eF -g -N 1023 -M878 -M296")
 set(D2D_FFLAGS_RELEASE "-O3")
 set(D2D_FFLAGS_DEBUG   "-O0 -g")

--- a/examples/cmake/D2D_CREATE_TEST.cmake
+++ b/examples/cmake/D2D_CREATE_TEST.cmake
@@ -39,6 +39,9 @@ macro(CreateMPITest run_dir
   target_link_libraries(${case} PRIVATE decomp2d examples_utils)
   if (OPENMP_FOUND AND ENABLE_OMP)
     target_link_libraries(${case} PRIVATE OpenMP::OpenMP_Fortran)
+    if (Fortran_COMPILER_NAME MATCHES "Cray")
+      target_link_options(${case} PRIVATE -h omp)
+    endif()
   endif()
   # Install
   install(TARGETS ${case} DESTINATION ${run_dir})

--- a/src/decomp_2d_constants.f90
+++ b/src/decomp_2d_constants.f90
@@ -132,8 +132,8 @@ module decomp_2d_constants
    ! Major and minor version number
    !
    integer, parameter :: D2D_MAJOR = 2
-   integer, parameter :: D2D_MINOR = 2
-   logical, parameter :: D2D_RELEASE = .false.
+   integer, parameter :: D2D_MINOR = 1
+   logical, parameter :: D2D_RELEASE = .true.
 
 end module decomp_2d_constants
 


### PR DESCRIPTION
Newer Cray compilers (CCE 16+?) require that OpenMP is linked explicitly, whereas older ones did not. CMake does not add `-h omp` to the link line, see https://gitlab.kitware.com/cmake/cmake/-/issues/26129 